### PR TITLE
Add separate adapters

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -16,13 +16,13 @@ module.exports = [
   // nil adapter
   {
     path: 'build/nil/index.js',
-    limit: '56 B',
+    limit: '58 B',
     import: '{ nil }',
     ignore: ['effector'],
   },
   {
     path: 'build/nil/index.cjs',
-    limit: '352 B',
+    limit: '355 B',
     import: '{ nil }',
     ignore: ['effector'],
   },
@@ -44,13 +44,13 @@ module.exports = [
   // localStorage
   {
     path: 'build/local/index.js',
-    limit: '1192 B',
+    limit: '1205 B',
     import: '{ persist }',
     ignore: ['effector'],
   },
   {
     path: 'build/local/index.cjs',
-    limit: '1481 B',
+    limit: '1497 B',
     import: '{ persist }',
     ignore: ['effector'],
   },
@@ -58,13 +58,13 @@ module.exports = [
   // sessionStorage
   {
     path: 'build/session/index.js',
-    limit: '1189 B',
+    limit: '1201 B',
     import: '{ persist }',
     ignore: ['effector'],
   },
   {
     path: 'build/session/index.cjs',
-    limit: '1477 B',
+    limit: '1496 B',
     import: '{ persist }',
     ignore: ['effector'],
   },
@@ -72,13 +72,13 @@ module.exports = [
   // query string
   {
     path: 'build/query/index.js',
-    limit: '1269 B',
+    limit: '1310 B',
     import: '{ persist }',
     ignore: ['effector'],
   },
   {
     path: 'build/query/index.cjs',
-    limit: '1582 B',
+    limit: '1629 B',
     import: '{ persist }',
     ignore: ['effector'],
   },
@@ -86,13 +86,13 @@ module.exports = [
   // memory
   {
     path: 'build/memory/index.js',
-    limit: '973 B',
+    limit: '993 B',
     import: '{ persist }',
     ignore: ['effector'],
   },
   {
     path: 'build/memory/index.cjs',
-    limit: '1227 B',
+    limit: '1254 B',
     import: '{ persist }',
     ignore: ['effector'],
   },
@@ -114,25 +114,25 @@ module.exports = [
   // react native async storages
   {
     path: 'build/rn/async/index.js',
-    limit: '1252 B',
+    limit: '1264 B',
     import: '{ persist }',
     ignore: ['effector', '@react-native-async-storage/async-storage'],
   },
   {
     path: 'build/rn/async/index.cjs',
-    limit: '1357 B',
+    limit: '1370 B',
     import: '{ persist }',
     ignore: ['effector', '@react-native-async-storage/async-storage'],
   },
   {
     path: 'build/rn/encrypted/index.js',
-    limit: '1252 B',
+    limit: '1264 B',
     import: '{ persist }',
     ignore: ['effector', 'react-native-encrypted-storage'],
   },
   {
     path: 'build/rn/encrypted/index.cjs',
-    limit: '1357 B',
+    limit: '1371 B',
     import: '{ persist }',
     ignore: ['effector', 'react-native-encrypted-storage'],
   },

--- a/src/async-storage/README.md
+++ b/src/async-storage/README.md
@@ -1,0 +1,37 @@
+# Generic asynchronous storage adapter
+
+Adapter to persist [_store_] in compatible asynchronous storage.
+
+## Usage
+
+```javascript
+import { persist } from 'effector-storage'
+import { asyncStorage } from 'effector-storage/async-storage'
+import AsyncStorage from '@react-native-async-storage/async-storage'
+
+// persist store `$counter` in `localStorage` with key 'counter'
+persist({
+  adapter: asyncStorage({ storage: AsyncStorage }),
+  store: $counter,
+  key: 'counter',
+})
+```
+
+Two (or more) different stores, persisted with the same key, will be synchronized, even if not connected with each other directly — each store will receive updates from another one.
+
+## Adapter
+
+```javascript
+import { asyncStorage } from 'effector-storage/async-storage'
+```
+
+- `storage(options): StorageAdapter`
+
+### Options
+
+- `storage` ([AsyncStorage]): Compatible asynchronous storage.
+- `serialize`? (_(value: any) => string_): Custom serialize function. Default = `JSON.stringify`.
+- `deserialize`? (_(value: string) => any_): Custom deserialize function. Default = `JSON.parse`.
+
+[asyncstorage]: https://reactnative.dev/docs/asyncstorage
+[_store_]: https://effector.dev/docs/api/effector/store

--- a/src/async-storage/index.ts
+++ b/src/async-storage/index.ts
@@ -12,7 +12,7 @@ export interface AsyncStorageConfig {
 }
 
 /**
- * Generic `AsyncStorage` adapter factory
+ * Creates generic `AsyncStorage` adapter
  */
 export function asyncStorage({
   storage,

--- a/src/local/README.md
+++ b/src/local/README.md
@@ -36,6 +36,20 @@ import { persist } from 'effector-storage/local'
 - `serialize`? (_(value: any) => string_): Custom serialize function. Default = `JSON.stringify`.
 - `deserialize`? (_(value: string) => any_): Custom deserialize function. Default = `JSON.parse`.
 
+## Adapter
+
+```javascript
+import { local } from 'effector-storage/local'
+```
+
+- `local(options?): StorageAdapter`
+
+### Options
+
+- `sync`? ([_boolean_]): Add [`'storage'`] event listener or no. Default = `true`.
+- `serialize`? (_(value: any) => string_): Custom serialize function. Default = `JSON.stringify`.
+- `deserialize`? (_(value: string) => any_): Custom deserialize function. Default = `JSON.parse`.
+
 ## FAQ
 
 ### How do I use custom serialization / deserialization?

--- a/src/memory/README.md
+++ b/src/memory/README.md
@@ -1,0 +1,48 @@
+# Memory adapter
+
+Adapter to persist [_store_] in memory. Useful for testing purposes and when other storage options are not available.
+
+## Usage
+
+Import `persist` function from `'effector-storage/memory'` module, and it will just work:
+
+```javascript
+import { persist } from 'effector-storage/memory'
+
+// persist store `$counter` with key 'counter'
+persist({ store: $counter, key: 'counter' })
+
+// if your storage has a name, you can omit `key` field
+persist({ store: $counter })
+```
+
+Two (or more) different stores, persisted with the same key, will be synchronized, even if not connected with each other directly — each store will receive updates from another one.
+
+## Formulae
+
+```javascript
+import { persist } from 'effector-storage/memory'
+```
+
+- `persist({ store, ...options }): Subscription`
+- `persist({ source, target, ...options }): Subscription`
+
+### Options
+
+- ... all the [common options](../../README.md#options) from root `persist` function.
+
+## Adapter
+
+```javascript
+import { memory } from 'effector-storage/memory'
+```
+
+- `memory(area?): StorageAdapter`
+
+### Options
+
+- `area`? ([_Map_]_<string, any>_): Map to store values. Default = common global map.
+
+[_subscription_]: https://effector.dev/docs/glossary#subscription
+[_store_]: https://effector.dev/docs/api/effector/store
+[_map_]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map

--- a/src/memory/adapter.ts
+++ b/src/memory/adapter.ts
@@ -2,7 +2,12 @@ import type { StorageAdapter } from '..'
 
 const data = new Map<string, any>()
 
-export const memory: StorageAdapter = <State>(key: string) => ({
-  get: () => data.get(key),
-  set: (value: State) => data.set(key, value),
-})
+export function memory(area: Map<string, any> = data): StorageAdapter {
+  const adapter: StorageAdapter = <State>(key: string) => ({
+    get: () => area.get(key),
+    set: (value: State) => area.set(key, value),
+  })
+
+  adapter.keyArea = area
+  return adapter
+}

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -30,13 +30,18 @@ export interface Persist {
 }
 
 /**
+ * Returns memory adapter
+ */
+export { memory }
+
+/**
  * Creates custom partially applied `persist`
  * with predefined `memory` adapter
  */
 export function createPersist(defaults?: ConfigPersist): Persist {
   return (config) =>
     base({
-      adapter: memory,
+      adapter: memory(),
       ...defaults,
       ...config,
     })

--- a/src/nil/README.md
+++ b/src/nil/README.md
@@ -1,0 +1,31 @@
+# Nil adapter
+
+"Do nothing" adapter, useful for test purposes and when other storage options are not available.
+
+## Usage
+
+```javascript
+import { persist } from 'effector-storage'
+import { nil } from 'effector-storage/nil'
+
+// persist store `$counter` with nil adapter == do nothing
+persist({
+  adapter: nil(),
+  store: $counter,
+  key: 'counter',
+})
+```
+
+Note though, that two (or more) different stores, persisted with the same key and same `keyArea`, will be synchronized nonetheless, even if not connected with each other directly — each store will receive updates from another one.
+
+## Adapter
+
+```javascript
+import { nil } from 'effector-storage/nil'
+```
+
+- `nil(keyArea?): StorageAdapter`
+
+### Options
+
+- `keyArea`? (any): Any value for adapter's key area. Default = `''`.

--- a/src/nil/index.ts
+++ b/src/nil/index.ts
@@ -3,7 +3,7 @@ import type { StorageAdapter } from '..'
 /**
  * Nil/Void adapter
  */
-export function nil(keyArea?: any): StorageAdapter {
+export function nil(keyArea: any = ''): StorageAdapter {
   const adapter: StorageAdapter = () =>
     <any>{
       get() {}, // eslint-disable-line @typescript-eslint/no-empty-function

--- a/src/query/README.md
+++ b/src/query/README.md
@@ -58,6 +58,20 @@ import { persist } from 'effector-storage/query'
 - `state`?: (`'keep'` | `'erase'`): If `method` is `pushState` or `replaceState` — should current state be preserved or replaced with `null`. Default = `keep`
 - `def`?: (_any_): Default value, which will be passed to `store`/`target` in case of absent query parameter. Default = `store.defaultState` or `null`
 
+## Adapter
+
+```javascript
+import { query } from 'effector-storage/query'
+```
+
+- `query(options?): StorageAdapter`
+
+### Options
+
+- `method`?: ([_function_]): One of `pushState`, `replaceState`, `locationAssign` or `locationReplace`. Default = `pushState`.
+- `state`?: (`'keep'` | `'erase'`): If `method` is `pushState` or `replaceState` — should current state be preserved or replaced with `null`. Default = `keep`
+- `def`?: (_any_): Default value, which will be passed to `store`/`target` in case of absent query parameter. Default = `null`
+
 ## FAQ
 
 ### How do I use custom serialization / deserialization?

--- a/src/query/adapter.ts
+++ b/src/query/adapter.ts
@@ -10,6 +10,7 @@ export type StateBehavior = 'keep' | 'erase'
 export interface QueryConfig {
   method?: ChangeMethod
   state?: StateBehavior
+  def?: any
 }
 
 const keyArea = Symbol() // eslint-disable-line symbol-description
@@ -38,10 +39,11 @@ export const locationReplace: ChangeMethod = (params): void =>
 /**
  * Query string adapter factory
  */
-export function query(
-  { method = pushState, state }: QueryConfig,
-  def: any
-): StorageAdapter {
+export function query({
+  method = pushState,
+  state,
+  def = null,
+}: QueryConfig): StorageAdapter {
   const adapter: StorageAdapter = <State>(
     key: string,
     update: (raw?: any) => any

--- a/src/query/index.ts
+++ b/src/query/index.ts
@@ -4,18 +4,20 @@ import type {
   ConfigCommon,
   ConfigJustStore,
   ConfigJustSourceTarget,
+  StorageAdapter,
 } from '../types'
-import type { ChangeMethod, StateBehavior } from './adapter'
+import type { ChangeMethod, StateBehavior, QueryConfig } from './adapter'
 import { persist as base } from '../persist'
 import { nil } from '../nil'
-import { query } from './adapter'
+import { query as adapter } from './adapter'
 
 export type { Done, Fail, Finally, StorageAdapter } from '../types'
+export type { ChangeMethod, StateBehavior, QueryConfig } from './adapter'
 export {
-  pushState,
-  replaceState,
   locationAssign,
   locationReplace,
+  pushState,
+  replaceState,
 } from './adapter'
 
 export interface ConfigPersist extends BaseConfigPersist {
@@ -45,6 +47,20 @@ export interface Persist {
 }
 
 /**
+ * Function, checking if `history` and `location` exists and accessible
+ */
+function supports() {
+  return typeof history !== 'undefined' && typeof location !== 'undefined'
+}
+
+/**
+ * Creates query string adapter
+ */
+export function query(config?: QueryConfig): StorageAdapter {
+  return supports() ? adapter({ ...config }) : nil('query')
+}
+
+/**
  * Creates custom partially applied `persist`
  * with predefined `query` adapter
  */
@@ -58,10 +74,7 @@ export function createPersist(defaults?: ConfigPersist): Persist {
         : null
 
     return base({
-      adapter:
-        typeof history !== 'undefined' && typeof location !== 'undefined'
-          ? query({ ...defaults, ...config }, def)
-          : nil('query'),
+      adapter: query({ ...defaults, ...config, def }),
       ...defaults,
       ...config,
     })

--- a/src/rn/async/README.md
+++ b/src/rn/async/README.md
@@ -41,6 +41,19 @@ import { persist } from 'effector-storage/rn/async'
 - `serialize`? (_(value: any) => string_): Custom serialize function. Default = `JSON.stringify`.
 - `deserialize`? (_(value: string) => any_): Custom deserialize function. Default = `JSON.parse`.
 
+## Adapter
+
+```javascript
+import { async } from 'effector-storage/rn/async'
+```
+
+- `async(options?): StorageAdapter`
+
+### Options
+
+- `serialize`? (_(value: any) => string_): Custom serialize function. Default = `JSON.stringify`.
+- `deserialize`? (_(value: string) => any_): Custom deserialize function. Default = `JSON.parse`.
+
 ## FAQ
 
 ### How do I use custom serialization / deserialization?

--- a/src/rn/async/index.ts
+++ b/src/rn/async/index.ts
@@ -4,7 +4,9 @@ import type {
   ConfigCommon,
   ConfigJustStore,
   ConfigJustSourceTarget,
+  StorageAdapter,
 } from '../../types'
+import type { AsyncStorageConfig as BaseAsyncStorageConfig } from '../../async-storage'
 import { persist as base } from '../../persist'
 import { asyncStorage } from '../../async-storage'
 import AsyncStorage from '@react-native-async-storage/async-storage'
@@ -33,6 +35,19 @@ export interface Persist {
   <State, Err = Error>(config: ConfigStore<State, Err>): Subscription
 }
 
+export interface AsyncStorageConfig
+  extends Omit<BaseAsyncStorageConfig, 'storage'> {}
+
+/**
+ * Creates `AsyncStorage` adapter
+ */
+export function async(config: AsyncStorageConfig): StorageAdapter {
+  return asyncStorage({
+    storage: AsyncStorage,
+    ...config,
+  })
+}
+
 /**
  * Creates custom partially applied `persist`
  * with predefined `AsyncStorage` adapter
@@ -40,11 +55,7 @@ export interface Persist {
 export function createPersist(defaults?: ConfigPersist): Persist {
   return (config) =>
     base({
-      adapter: asyncStorage({
-        storage: AsyncStorage,
-        ...defaults,
-        ...config,
-      }),
+      adapter: async({ ...defaults, ...config }),
       ...defaults,
       ...config,
     })

--- a/src/rn/encrypted/README.md
+++ b/src/rn/encrypted/README.md
@@ -41,6 +41,19 @@ import { persist } from 'effector-storage/rn/encrypted'
 - `serialize`? (_(value: any) => string_): Custom serialize function. Default = `JSON.stringify`.
 - `deserialize`? (_(value: string) => any_): Custom deserialize function. Default = `JSON.parse`.
 
+## Adapter
+
+```javascript
+import { encrypted } from 'effector-storage/rn/encrypted'
+```
+
+- `encrypted(options?): StorageAdapter`
+
+### Options
+
+- `serialize`? (_(value: any) => string_): Custom serialize function. Default = `JSON.stringify`.
+- `deserialize`? (_(value: string) => any_): Custom deserialize function. Default = `JSON.parse`.
+
 ## FAQ
 
 ### How do I use custom serialization / deserialization?

--- a/src/rn/encrypted/index.ts
+++ b/src/rn/encrypted/index.ts
@@ -4,7 +4,9 @@ import type {
   ConfigCommon,
   ConfigJustStore,
   ConfigJustSourceTarget,
+  StorageAdapter,
 } from '../../types'
+import type { AsyncStorageConfig as BaseAsyncStorageConfig } from '../../async-storage'
 import { persist as base } from '../../persist'
 import { asyncStorage } from '../../async-storage'
 import EncryptedStorage from 'react-native-encrypted-storage'
@@ -33,6 +35,19 @@ export interface Persist {
   <State, Err = Error>(config: ConfigStore<State, Err>): Subscription
 }
 
+export interface EncryptedStorageConfig
+  extends Omit<BaseAsyncStorageConfig, 'storage'> {}
+
+/**
+ * Creates `EncryptedStorage` adapter
+ */
+export function encrypted(config: EncryptedStorageConfig): StorageAdapter {
+  return asyncStorage({
+    storage: EncryptedStorage,
+    ...config,
+  })
+}
+
 /**
  * Creates custom partially applied `persist`
  * with predefined `EncryptedStorage` adapter
@@ -40,11 +55,7 @@ export interface Persist {
 export function createPersist(defaults?: ConfigPersist): Persist {
   return (config) =>
     base({
-      adapter: asyncStorage({
-        storage: EncryptedStorage,
-        ...defaults,
-        ...config,
-      }),
+      adapter: encrypted({ ...defaults, ...config }),
       ...defaults,
       ...config,
     })

--- a/src/session/README.md
+++ b/src/session/README.md
@@ -34,6 +34,20 @@ import { persist } from 'effector-storage/session'
 - `serialize`? (_(value: any) => string_): Custom serialize function. Default = `JSON.stringify`.
 - `deserialize`? (_(value: string) => any_): Custom deserialize function. Default = `JSON.parse`.
 
+## Adapter
+
+```javascript
+import { session } from 'effector-storage/session'
+```
+
+- `session(options?): StorageAdapter`
+
+### Options
+
+- `sync`? ([_boolean_]): Add [`'storage'`] event listener or no. Default = `false`.
+- `serialize`? (_(value: any) => string_): Custom serialize function. Default = `JSON.stringify`.
+- `deserialize`? (_(value: string) => any_): Custom deserialize function. Default = `JSON.parse`.
+
 ## FAQ
 
 ### How do I use custom serialization / deserialization?

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -4,7 +4,9 @@ import type {
   ConfigCommon,
   ConfigJustStore,
   ConfigJustSourceTarget,
+  StorageAdapter,
 } from '../types'
+import type { StorageConfig } from '../storage'
 import { persist as base } from '../persist'
 import { nil } from '../nil'
 import { storage } from '../storage'
@@ -36,6 +38,8 @@ export interface Persist {
   <State, Err = Error>(config: ConfigStore<State, Err>): Subscription
 }
 
+export interface SessionStorageConfig extends Omit<StorageConfig, 'storage'> {}
+
 /**
  * Function, checking if `sessionStorage` exists and accessible
  */
@@ -48,19 +52,25 @@ function supports() {
 }
 
 /**
+ * Creates `sessionStorage` adapter
+ */
+export function session(config?: SessionStorageConfig): StorageAdapter {
+  return supports()
+    ? storage({
+        storage: sessionStorage,
+        ...config,
+      })
+    : nil('session')
+}
+
+/**
  * Creates custom partially applied `persist`
  * with predefined `sessionStorage` adapter
  */
 export function createPersist(defaults?: ConfigPersist): Persist {
   return (config) =>
     base({
-      adapter: supports()
-        ? storage({
-            storage: sessionStorage,
-            ...defaults,
-            ...config,
-          })
-        : nil('session'),
+      adapter: session({ ...defaults, ...config }),
       ...defaults,
       ...config,
     })

--- a/src/storage/README.md
+++ b/src/storage/README.md
@@ -1,0 +1,39 @@
+# Generic synchronous storage adapter
+
+Adapter to persist [_store_] in browser's [Storage].
+
+## Usage
+
+```javascript
+import { persist } from 'effector-storage'
+import { storage } from 'effector-storage/storage'
+
+// persist store `$counter` in `localStorage` with key 'counter'
+persist({
+  adapter: storage({ storage: localStorage }),
+  store: $counter,
+  key: 'counter',
+})
+```
+
+Two (or more) different stores, persisted with the same key, will be synchronized, even if not connected with each other directly — each store will receive updates from another one.
+
+## Adapter
+
+```javascript
+import { storage } from 'effector-storage/storage'
+```
+
+- `storage(options): StorageAdapter`
+
+### Options
+
+- `storage` ([Storage]): Compatible synchronous storage.
+- `sync`? ([_boolean_]): Add [`'storage'`] event listener or no. Default = `false`.
+- `serialize`? (_(value: any) => string_): Custom serialize function. Default = `JSON.stringify`.
+- `deserialize`? (_(value: string) => any_): Custom deserialize function. Default = `JSON.parse`.
+
+[storage]: https://developer.mozilla.org/en-US/docs/Web/API/Storage
+[`'storage'`]: https://developer.mozilla.org/en-US/docs/Web/API/StorageEvent
+[_store_]: https://effector.dev/docs/api/effector/store
+[_boolean_]: https://developer.mozilla.org/en-US/docs/Glossary/Boolean

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -8,7 +8,7 @@ export interface StorageConfig {
 }
 
 /**
- * Generic `Storage` adapter factory
+ * Creates generic `Storage` adapter
  */
 export function storage({
   storage,

--- a/tests/adapters.test.ts
+++ b/tests/adapters.test.ts
@@ -1,0 +1,72 @@
+import { test } from 'uvu'
+import * as assert from 'uvu/assert'
+import { createStore } from 'effector'
+import { createStorageMock } from './mocks/storage.mock'
+import { createEventsMock } from './mocks/events.mock'
+import { createHistoryMock } from './mocks/history.mock'
+import { createLocationMock } from './mocks/location.mock'
+import { persist } from '../src'
+import { local } from '../src/local'
+import { session } from '../src/session'
+import { query } from '../src/query'
+
+//
+// Mock `localStorage` and events
+//
+
+declare let global: any
+let events: ReturnType<typeof createEventsMock>
+
+test.before(() => {
+  global.localStorage = createStorageMock()
+  global.sessionStorage = createStorageMock()
+  events = createEventsMock()
+  global.addEventListener = events.addEventListener
+  global.history = createHistoryMock(null, '', 'http://domain.test')
+  global.location = createLocationMock('http://domain.test')
+  global.history._location(global.location)
+  global.location._history(global.history)
+})
+
+test.after(() => {
+  delete global.localStorage
+  delete global.sessionStorage
+  delete global.addEventListener
+  delete global.history
+  delete global.location
+})
+
+//
+// Tests
+//
+
+test('should be possible to use different adapters', async () => {
+  const $counter = createStore(0, { name: 'counter' })
+  persist({ adapter: local(), store: $counter })
+  persist({ adapter: session(), store: $counter })
+  persist({ adapter: query({ def: 0 }), store: $counter })
+  assert.is($counter.getState(), 0)
+
+  global.localStorage.setItem('counter', '1')
+  await events.dispatchEvent('storage', {
+    storageArea: global.localStorage,
+    key: 'counter',
+    oldValue: null,
+    newValue: '1',
+  })
+
+  assert.is($counter.getState(), 1)
+
+  // should update `sessionStorage`
+  // because store got updated from `localStorage`
+  assert.is(global.sessionStorage.getItem('counter'), '1')
+
+  // should update query string as well
+  assert.is(global.location.search, '?counter=1')
+})
+
+//
+// Launch tests
+//
+
+test.run()

--- a/tests/local.test.ts
+++ b/tests/local.test.ts
@@ -3,7 +3,7 @@ import * as assert from 'uvu/assert'
 import { createStore } from 'effector'
 import { createStorageMock } from './mocks/storage.mock'
 import { createEventsMock } from './mocks/events.mock'
-import { persist } from '../src/local'
+import { local, persist } from '../src/local'
 
 //
 // Mock `localStorage` and events
@@ -28,6 +28,7 @@ test.after(() => {
 //
 
 test('should export adapter and `persist` function', () => {
+  assert.type(local, 'function')
   assert.type(persist, 'function')
 })
 

--- a/tests/memory.test.ts
+++ b/tests/memory.test.ts
@@ -2,13 +2,14 @@ import { test } from 'uvu'
 import * as assert from 'uvu/assert'
 import { snoop } from 'snoop'
 import { createStore } from 'effector'
-import { persist } from '../src/memory'
+import { memory, persist } from '../src/memory'
 
 //
 // Tests
 //
 
 test('should export adapter and `persist` function', () => {
+  assert.type(memory, 'function')
   assert.type(persist, 'function')
 })
 

--- a/tests/query.test.ts
+++ b/tests/query.test.ts
@@ -7,6 +7,7 @@ import { createLocationMock } from './mocks/location.mock'
 import { createEventsMock } from './mocks/events.mock'
 import {
   persist,
+  query,
   pushState,
   replaceState,
   locationAssign,
@@ -40,6 +41,7 @@ test.after.each(() => {
 //
 
 test('should export adapter and `persist` function', () => {
+  assert.type(query, 'function')
   assert.type(persist, 'function')
   assert.type(pushState, 'function')
   assert.type(replaceState, 'function')

--- a/tests/rn-async.test.ts
+++ b/tests/rn-async.test.ts
@@ -2,7 +2,7 @@ import { test } from 'uvu'
 import * as assert from 'uvu/assert'
 import { createStore } from 'effector'
 import { createStorageMock } from './mocks/storage.mock'
-import { persist } from '../src/rn/async'
+import { async, persist } from '../src/rn/async'
 
 //
 // Mock `localStorage`
@@ -30,6 +30,7 @@ test.after(() => {
 //
 
 test('should export adapter and `persist` function', () => {
+  assert.type(async, 'function')
   assert.type(persist, 'function')
 })
 

--- a/tests/rn-encrypted.test.ts
+++ b/tests/rn-encrypted.test.ts
@@ -8,7 +8,8 @@ import * as assert from 'uvu/assert'
 test('should export adapter and `persist` function', async () => {
   try {
     // I'm not sure, how to mock 'react-native-encrypted-storage' module ???
-    const { persist } = await import('../src/rn/encrypted')
+    const { encrypted, persist } = await import('../src/rn/encrypted')
+    assert.type(encrypted, 'function')
     assert.type(persist, 'function')
   } catch (e) {
     console.log('// todo: skipped test')

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -2,7 +2,7 @@ import { test } from 'uvu'
 import * as assert from 'uvu/assert'
 import { createStore } from 'effector'
 import { createStorageMock } from './mocks/storage.mock'
-import { persist } from '../src/session'
+import { session, persist } from '../src/session'
 
 //
 // Mock `sessionStorage`
@@ -23,6 +23,7 @@ test.after(() => {
 //
 
 test('should export adapter and `persist` function', () => {
+  assert.type(session, 'function')
   assert.type(persist, 'function')
 })
 


### PR DESCRIPTION
Sometimes it is required to persist different stores with different adapters within the same model (file). And to avoid names clashes you should write smth like this:

```js
import { persist as localPersist } from 'effector-storage/local'
import { persist as queryPersist } from 'effector-storage/query'

// ...

localPersist({ store: $session })
queryPersist({ store: $page })
```

This PR adds exported adapters themselves to use with core `persist` function:

```js
import { persist } from 'effector-storage'
import { local } from 'effector-storage/local'
import { query } from 'effector-storage/query'

// ...

persist({ adapter: local(), store: $session })
persist({ adapter: query(), store: $page })
```
