### PR TITLE
Export main adapters from module root index

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -1,26 +1,30 @@
 module.exports = [
   // core
   {
+    name: 'core persist, es module',
     path: 'build/index.js',
     limit: '743 B',
     import: '{ persist }',
     ignore: ['effector'],
   },
   {
+    name: 'core persist, cjs module',
     path: 'build/index.cjs',
-    limit: '1165 B',
+    limit: '2222 B',
     import: '{ persist }',
     ignore: ['effector'],
   },
 
   // nil adapter
   {
+    name: 'nil adapter, es module',
     path: 'build/nil/index.js',
     limit: '58 B',
     import: '{ nil }',
     ignore: ['effector'],
   },
   {
+    name: 'nil adapter, cjs module',
     path: 'build/nil/index.cjs',
     limit: '355 B',
     import: '{ nil }',
@@ -29,12 +33,14 @@ module.exports = [
 
   // storage adapter
   {
+    name: 'storage adapter, es module',
     path: 'build/storage/index.js',
     limit: '230 B',
     import: '{ storage }',
     ignore: ['effector'],
   },
   {
+    name: 'storage adapter, cjs module',
     path: 'build/storage/index.cjs',
     limit: '512 B',
     import: '{ storage }',
@@ -43,26 +49,50 @@ module.exports = [
 
   // localStorage
   {
+    name: '`localStorage` persist, es module',
     path: 'build/local/index.js',
     limit: '1182 B',
     import: '{ persist }',
     ignore: ['effector'],
   },
   {
+    name: '`localStorage` persist, cjs module',
     path: 'build/local/index.cjs',
     limit: '1476 B',
     import: '{ persist }',
     ignore: ['effector'],
   },
 
+  // localStorage, but using adapter
+  // should be ~ the same size as direct import
+  {
+    name: 'core persist + `localStorage` adapter, es module',
+    path: 'build/index.js',
+    limit: '1190 B',
+    import: '{ persist, local }',
+    ignore: ['effector'],
+  },
+  {
+    name: 'core persist + `localStorage` adapter factory, es module',
+    path: ['build/index.js', 'build/local/index.js'],
+    limit: '1191 B',
+    import: {
+      'build/index.js': '{ persist }',
+      'build/local/index.js': '{ local }',
+    },
+    ignore: ['effector'],
+  },
+
   // sessionStorage
   {
+    name: '`sessionStorage` persist, es module',
     path: 'build/session/index.js',
     limit: '1180 B',
     import: '{ persist }',
     ignore: ['effector'],
   },
   {
+    name: '`sessionStorage` persist, cjs module',
     path: 'build/session/index.cjs',
     limit: '1467 B',
     import: '{ persist }',
@@ -71,12 +101,14 @@ module.exports = [
 
   // query string
   {
+    name: 'query string persist, es module',
     path: 'build/query/index.js',
     limit: '1298 B',
     import: '{ persist }',
     ignore: ['effector'],
   },
   {
+    name: 'query string persist, cjs module',
     path: 'build/query/index.cjs',
     limit: '1605 B',
     import: '{ persist }',
@@ -85,12 +117,14 @@ module.exports = [
 
   // memory
   {
+    name: 'memory adapter, es module',
     path: 'build/memory/index.js',
     limit: '975 B',
     import: '{ persist }',
     ignore: ['effector'],
   },
   {
+    name: 'memory adapter, cjs module',
     path: 'build/memory/index.cjs',
     limit: '1226 B',
     import: '{ persist }',
@@ -99,12 +133,14 @@ module.exports = [
 
   // async storage adapter
   {
+    name: 'generic async storage adapter, es module',
     path: 'build/async-storage/index.js',
     limit: '143 B',
     import: '{ asyncStorage }',
     ignore: ['effector'],
   },
   {
+    name: 'generic async storage adapter, cjs module',
     path: 'build/async-storage/index.cjs',
     limit: '438 B',
     import: '{ asyncStorage }',
@@ -113,24 +149,28 @@ module.exports = [
 
   // react native async storages
   {
+    name: '`AsyncStorage` persist, es module',
     path: 'build/rn/async/index.js',
     limit: '1246 B',
     import: '{ persist }',
     ignore: ['effector', '@react-native-async-storage/async-storage'],
   },
   {
+    name: '`AsyncStorage` persist, cjs module',
     path: 'build/rn/async/index.cjs',
     limit: '1346 B',
     import: '{ persist }',
     ignore: ['effector', '@react-native-async-storage/async-storage'],
   },
   {
+    name: '`EncryptedStorage` persist, es module',
     path: 'build/rn/encrypted/index.js',
     limit: '1245 B',
     import: '{ persist }',
     ignore: ['effector', 'react-native-encrypted-storage'],
   },
   {
+    name: '`EncryptedStorage` persist, cjs module',
     path: 'build/rn/encrypted/index.cjs',
     limit: '1346 B',
     import: '{ persist }',

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -8,6 +8,22 @@ import generatePackageJson from 'rollup-plugin-generate-package-json'
 const SRC = 'src'
 const BUILD = 'build'
 
+const external = [
+  'effector',
+  'react-native-encrypted-storage',
+  '@react-native-async-storage/async-storage',
+  /\.[./]*\/core/,
+  /\.[./]*\/nil/,
+  /\.[./]*\/storage/,
+  /\.[./]*\/local/,
+  /\.[./]*\/session/,
+  /\.[./]*\/query/,
+  /\.[./]*\/memory/,
+  /\.[./]*\/async-storage/,
+  /\.[./]*\/rn\/async/,
+  /\.[./]*\/rn\/encrypted/,
+]
+
 const src = (name) => ({
   input: `${SRC}/${name}index.ts`,
   output: [
@@ -26,17 +42,7 @@ const src = (name) => ({
       exports: 'named',
     },
   ],
-  external: [
-    'effector',
-    'react-native-encrypted-storage',
-    '@react-native-async-storage/async-storage',
-    './core',
-    '../core',
-    '../../core',
-    '../storage',
-    '../nil',
-    '../../async-storage',
-  ],
+  external,
   plugins: [
     // resolve typescript files
     nodeResolve({
@@ -82,16 +88,17 @@ const src = (name) => ({
               bugs: pkg.bugs,
               homepage: pkg.homepage,
               keywords: pkg.keywords,
-              types: 'index.d.ts',
               peerDependencies: {
                 effector: '>=21.0.0',
               },
 
               // cjs + esm magic
               type: 'module',
+              sideEffects: false,
               main: 'index.cjs',
               module: 'index.js',
               'react-native': 'index.js',
+              types: 'index.d.ts',
               exports: {
                 './package.json': './package.json',
                 '.': {
@@ -155,6 +162,7 @@ const src = (name) => ({
           {
             baseContents: {
               type: 'module',
+              sideEffects: false,
               main: 'index.cjs',
               module: 'index.js',
               'react-native': 'index.js',
@@ -176,17 +184,7 @@ const dts = (name) => ({
       format: 'es',
     },
   ],
-  external: [
-    'effector',
-    'react-native-encrypted-storage',
-    '@react-native-async-storage/async-storage',
-    './core',
-    '../core',
-    '../../core',
-    '../storage',
-    '../nil',
-    '../../async-storage',
-  ],
+  external,
   plugins: [
     generateDts({ respectExternal: true }),
     command(
@@ -207,17 +205,7 @@ const cjsdts = (name) => ({
       format: 'es',
     },
   ],
-  external: [
-    'effector',
-    'react-native-encrypted-storage',
-    '@react-native-async-storage/async-storage',
-    './core',
-    '../core',
-    '../../core',
-    '../storage',
-    '../nil',
-    '../../async-storage',
-  ],
+  external,
   plugins: [
     generateDts({ respectExternal: true }),
     command([`pnpm exec prettier --write ${BUILD}/${name}index.cjs.d.ts`], {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,24 @@ export type {
   StorageAdapter,
 } from './types'
 
+//
+// reexport adapters
+//
+
+export type { AsyncStorageConfig } from './async-storage'
+export type { LocalStorageConfig } from './local'
+export type { QueryConfig } from './query'
+export type { SessionStorageConfig } from './session'
+export type { StorageConfig } from './storage'
+
+export { asyncStorage } from './async-storage'
+export { local } from './local'
+export { memory } from './memory'
+export { nil } from './nil'
+export { query } from './query'
+export { session } from './session'
+export { storage } from './storage'
+
 /**
  * Creates custom `persist`
  */


### PR DESCRIPTION
Improve PR #36 further:

Instead of

```js
import { persist } from 'effector-storage'
import { local } from 'effector-storage/local'
import { query } from 'effector-storage/query'

// ...

persist({ adapter: local(), store: $session })
persist({ adapter: query(), store: $page })
```

it is possible to write

```js
import { persist, local, query } from 'effector-storage'

// ...

persist({ adapter: local(), store: $session })
persist({ adapter: query(), store: $page })
```

⚠️ Note though, that tree shaking will work only with ES modules