### PR TITLE
Add adapter utility functions

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -10,8 +10,8 @@ module.exports = [
   {
     name: 'root persist, cjs module',
     path: 'build/index.cjs',
-    limit: '2261 B',
-    import: '{ persist }',
+    limit: '2288 B',
+    // import: '{ persist }', // tree-shaking is not working with cjs
     ignore: ['effector'],
   },
 
@@ -26,8 +26,24 @@ module.exports = [
   {
     name: 'core persist, cjs module',
     path: 'build/core/index.cjs',
-    limit: '1012 B',
-    import: '{ persist }',
+    limit: '929 B',
+    // import: '{ persist }', // tree-shaking is not working with cjs
+    ignore: ['effector'],
+  },
+
+  // tools
+  {
+    name: 'tools, es module',
+    path: 'build/tools/index.js',
+    limit: '35 B',
+    import: '{ either }',
+    ignore: ['effector'],
+  },
+  {
+    name: 'tools, cjs module',
+    path: 'build/tools/index.cjs',
+    limit: '100 B',
+    // import: '{ either }', // tree-shaking is not working with cjs
     ignore: ['effector'],
   },
 
@@ -35,15 +51,15 @@ module.exports = [
   {
     name: 'nil adapter, es module',
     path: 'build/nil/index.js',
-    limit: '58 B',
+    limit: '68 B',
     import: '{ nil }',
     ignore: ['effector'],
   },
   {
     name: 'nil adapter, cjs module',
     path: 'build/nil/index.cjs',
-    limit: '355 B',
-    import: '{ nil }',
+    limit: '124 B',
+    // import: '{ nil }', // tree-shaking is not working with cjs
     ignore: ['effector'],
   },
 
@@ -58,8 +74,8 @@ module.exports = [
   {
     name: 'storage adapter, cjs module',
     path: 'build/storage/index.cjs',
-    limit: '530 B',
-    import: '{ storage }',
+    limit: '302 B',
+    // import: '{ storage }', // tree-shaking is not working with cjs
     ignore: ['effector'],
   },
 
@@ -67,15 +83,15 @@ module.exports = [
   {
     name: '`localStorage` persist, es module',
     path: 'build/local/index.js',
-    limit: '1267 B',
+    limit: '1274 B',
     import: '{ persist }',
     ignore: ['effector'],
   },
   {
     name: '`localStorage` persist, cjs module',
     path: 'build/local/index.cjs',
-    limit: '1551 B',
-    import: '{ persist }',
+    limit: '1540 B',
+    // import: '{ persist }', // tree-shaking is not working with cjs
     ignore: ['effector'],
   },
 
@@ -84,14 +100,14 @@ module.exports = [
   {
     name: 'core persist + `localStorage` adapter, es module',
     path: 'build/index.js',
-    limit: '1273 B',
+    limit: '1280 B',
     import: '{ persist, local }',
     ignore: ['effector'],
   },
   {
     name: 'core persist + `localStorage` adapter factory, es module',
     path: ['build/index.js', 'build/local/index.js'],
-    limit: '1274 B',
+    limit: '1282 B',
     import: {
       'build/index.js': '{ persist }',
       'build/local/index.js': '{ local }',
@@ -103,15 +119,15 @@ module.exports = [
   {
     name: '`sessionStorage` persist, es module',
     path: 'build/session/index.js',
-    limit: '1266 B',
+    limit: '1273 B',
     import: '{ persist }',
     ignore: ['effector'],
   },
   {
     name: '`sessionStorage` persist, cjs module',
     path: 'build/session/index.cjs',
-    limit: '1547 B',
-    import: '{ persist }',
+    limit: '1540 B',
+    // import: '{ persist }', // tree-shaking is not working with cjs
     ignore: ['effector'],
   },
 
@@ -119,15 +135,15 @@ module.exports = [
   {
     name: 'query string persist, es module',
     path: 'build/query/index.js',
-    limit: '1297 B',
+    limit: '1304 B',
     import: '{ persist }',
     ignore: ['effector'],
   },
   {
     name: 'query string persist, cjs module',
     path: 'build/query/index.cjs',
-    limit: '1604 B',
-    import: '{ persist }',
+    limit: '1601 B',
+    // import: '{ persist }', // tree-shaking is not working with cjs
     ignore: ['effector'],
   },
 
@@ -142,8 +158,8 @@ module.exports = [
   {
     name: 'memory adapter, cjs module',
     path: 'build/memory/index.cjs',
-    limit: '1226 B',
-    import: '{ persist }',
+    limit: '1205 B',
+    // import: '{ persist }', // tree-shaking is not working with cjs
     ignore: ['effector'],
   },
 
@@ -158,8 +174,8 @@ module.exports = [
   {
     name: 'generic async storage adapter, cjs module',
     path: 'build/async-storage/index.cjs',
-    limit: '453 B',
-    import: '{ asyncStorage }',
+    limit: '216 B',
+    // import: '{ asyncStorage }', // tree-shaking is not working with cjs
     ignore: ['effector'],
   },
 
@@ -174,8 +190,8 @@ module.exports = [
   {
     name: '`AsyncStorage` persist, cjs module',
     path: 'build/rn/async/index.cjs',
-    limit: '1360 B',
-    import: '{ persist }',
+    limit: '1331 B',
+    // import: '{ persist }', // tree-shaking is not working with cjs
     ignore: ['effector', '@react-native-async-storage/async-storage'],
   },
   {
@@ -188,8 +204,8 @@ module.exports = [
   {
     name: '`EncryptedStorage` persist, cjs module',
     path: 'build/rn/encrypted/index.cjs',
-    limit: '1360 B',
-    import: '{ persist }',
+    limit: '1333 B',
+    // import: '{ persist }', // tree-shaking is not working with cjs
     ignore: ['effector', 'react-native-encrypted-storage'],
   },
 ]

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -1,16 +1,32 @@
 module.exports = [
-  // core
+  // root
   {
-    name: 'core persist, es module',
+    name: 'root persist, es module',
     path: 'build/index.js',
     limit: '743 B',
     import: '{ persist }',
     ignore: ['effector'],
   },
   {
-    name: 'core persist, cjs module',
+    name: 'root persist, cjs module',
     path: 'build/index.cjs',
-    limit: '2246 B',
+    limit: '2261 B',
+    import: '{ persist }',
+    ignore: ['effector'],
+  },
+
+  // core
+  {
+    name: 'core persist, es module',
+    path: 'build/core/index.js',
+    limit: '738 B',
+    import: '{ persist }',
+    ignore: ['effector'],
+  },
+  {
+    name: 'core persist, cjs module',
+    path: 'build/core/index.cjs',
+    limit: '1012 B',
     import: '{ persist }',
     ignore: ['effector'],
   },
@@ -35,14 +51,14 @@ module.exports = [
   {
     name: 'storage adapter, es module',
     path: 'build/storage/index.js',
-    limit: '233 B',
+    limit: '247 B',
     import: '{ storage }',
     ignore: ['effector'],
   },
   {
     name: 'storage adapter, cjs module',
     path: 'build/storage/index.cjs',
-    limit: '516 B',
+    limit: '530 B',
     import: '{ storage }',
     ignore: ['effector'],
   },
@@ -51,14 +67,14 @@ module.exports = [
   {
     name: '`localStorage` persist, es module',
     path: 'build/local/index.js',
-    limit: '1254 B',
+    limit: '1267 B',
     import: '{ persist }',
     ignore: ['effector'],
   },
   {
     name: '`localStorage` persist, cjs module',
     path: 'build/local/index.cjs',
-    limit: '1536 B',
+    limit: '1551 B',
     import: '{ persist }',
     ignore: ['effector'],
   },
@@ -68,14 +84,14 @@ module.exports = [
   {
     name: 'core persist + `localStorage` adapter, es module',
     path: 'build/index.js',
-    limit: '1259 B',
+    limit: '1273 B',
     import: '{ persist, local }',
     ignore: ['effector'],
   },
   {
     name: 'core persist + `localStorage` adapter factory, es module',
     path: ['build/index.js', 'build/local/index.js'],
-    limit: '1261 B',
+    limit: '1274 B',
     import: {
       'build/index.js': '{ persist }',
       'build/local/index.js': '{ local }',
@@ -87,14 +103,14 @@ module.exports = [
   {
     name: '`sessionStorage` persist, es module',
     path: 'build/session/index.js',
-    limit: '1252 B',
+    limit: '1266 B',
     import: '{ persist }',
     ignore: ['effector'],
   },
   {
     name: '`sessionStorage` persist, cjs module',
     path: 'build/session/index.cjs',
-    limit: '1533 B',
+    limit: '1547 B',
     import: '{ persist }',
     ignore: ['effector'],
   },
@@ -135,14 +151,14 @@ module.exports = [
   {
     name: 'generic async storage adapter, es module',
     path: 'build/async-storage/index.js',
-    limit: '143 B',
+    limit: '157 B',
     import: '{ asyncStorage }',
     ignore: ['effector'],
   },
   {
     name: 'generic async storage adapter, cjs module',
     path: 'build/async-storage/index.cjs',
-    limit: '438 B',
+    limit: '453 B',
     import: '{ asyncStorage }',
     ignore: ['effector'],
   },
@@ -151,28 +167,28 @@ module.exports = [
   {
     name: '`AsyncStorage` persist, es module',
     path: 'build/rn/async/index.js',
-    limit: '1246 B',
+    limit: '1259 B',
     import: '{ persist }',
     ignore: ['effector', '@react-native-async-storage/async-storage'],
   },
   {
     name: '`AsyncStorage` persist, cjs module',
     path: 'build/rn/async/index.cjs',
-    limit: '1346 B',
+    limit: '1360 B',
     import: '{ persist }',
     ignore: ['effector', '@react-native-async-storage/async-storage'],
   },
   {
     name: '`EncryptedStorage` persist, es module',
     path: 'build/rn/encrypted/index.js',
-    limit: '1245 B',
+    limit: '1259 B',
     import: '{ persist }',
     ignore: ['effector', 'react-native-encrypted-storage'],
   },
   {
     name: '`EncryptedStorage` persist, cjs module',
     path: 'build/rn/encrypted/index.cjs',
-    limit: '1346 B',
+    limit: '1360 B',
     import: '{ persist }',
     ignore: ['effector', 'react-native-encrypted-storage'],
   },

--- a/.yaspeller.json
+++ b/.yaspeller.json
@@ -19,6 +19,7 @@
     "IndexedDB",
     "keyArea",
     "localStorage",
+    "noop",
     "patronum",
     "Payload",
     "pushState",

--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ interface StorageAdapter {
     set(value: State): void
   }
   keyArea?: any
+  noop?: boolean
 }
 ```
 
@@ -279,6 +280,10 @@ interface StorageAdapter {
 
 Adapter function can have static field `keyArea` — this could be any value of any type, which should be unique for _keys namespace_. For example, two local storage adapters could have different settings, but both of them uses same _storage area_ — `localStorage`. So, different stores, persisted in local storage with the same key (but possibly with different adapters), should be synced. That is what `keyArea` is responsible for. Value of that field is used as a key in cache `Map`.<br>
 In case it is omitted — adapter instances is used instead.
+
+#### noop
+
+Marks adapter as "no-op" for [`either`](https://github.com/yumauri/effector-storage/tree/master/src/tools/README.md#either) function.
 
 ### Synchronous storage adapter example
 

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -13,6 +13,7 @@ const external = [
   'react-native-encrypted-storage',
   '@react-native-async-storage/async-storage',
   /\.[./]*\/core/,
+  /\.[./]*\/tools/,
   /\.[./]*\/nil/,
   /\.[./]*\/storage/,
   /\.[./]*\/local/,
@@ -109,6 +110,11 @@ const src = (name) => ({
                 './core': {
                   require: './core/index.cjs',
                   import: './core/index.js',
+                },
+                './tools/package.json': './tools/package.json',
+                './tools': {
+                  require: './tools/index.cjs',
+                  import: './tools/index.js',
                 },
                 './nil/package.json': './nil/package.json',
                 './nil': {
@@ -219,6 +225,7 @@ const entry = (name) => [src(name), dts(name), cjsdts(name)]
 export default [
   ...entry(''),
   ...entry('core/'),
+  ...entry('tools/'),
   ...entry('nil/'),
   ...entry('storage/'),
   ...entry('local/'),

--- a/src/async-storage/README.md
+++ b/src/async-storage/README.md
@@ -29,7 +29,7 @@ import { asyncStorage } from 'effector-storage/async-storage'
 
 ### Options
 
-- `storage` ([AsyncStorage]): Compatible asynchronous storage.
+- `storage` (_() => [AsyncStorage]_): Compatible asynchronous storage.
 - `serialize`? (_(value: any) => string_): Custom serialize function. Default = `JSON.stringify`.
 - `deserialize`? (_(value: string) => any_): Custom deserialize function. Default = `JSON.parse`.
 

--- a/src/async-storage/index.ts
+++ b/src/async-storage/index.ts
@@ -6,7 +6,7 @@ export interface AsyncStorage {
 }
 
 export interface AsyncStorageConfig {
-  storage: AsyncStorage
+  storage: () => AsyncStorage
   serialize?: (value: any) => string
   deserialize?: (value: string) => any
 }
@@ -21,15 +21,20 @@ export function asyncStorage({
 }: AsyncStorageConfig): StorageAdapter {
   const adapter: StorageAdapter = <State>(key: string) => ({
     async get() {
-      const item = await storage.getItem(key)
+      const item = await storage().getItem(key)
       return item === null ? undefined : deserialize(item)
     },
 
     async set(value: State) {
-      await storage.setItem(key, serialize(value))
+      await storage().setItem(key, serialize(value))
     },
   })
 
-  adapter.keyArea = storage
+  try {
+    adapter.keyArea = storage()
+  } catch (error) {
+    // do nothing
+  }
+
   return adapter
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,12 @@ export { query } from './query'
 export { session } from './session'
 export { storage } from './storage'
 
+//
+// reexport tools
+//
+
+export { either } from './tools'
+
 /**
  * Creates custom `persist`
  */

--- a/src/local/index.ts
+++ b/src/local/index.ts
@@ -42,13 +42,15 @@ export interface Persist {
 export interface LocalStorageConfig extends Omit<StorageConfig, 'storage'> {}
 
 /**
- * Function, checking if `localStorage` exists and accessible
+ * Function, checking if `localStorage` exists
  */
 function supports() {
   try {
     return typeof localStorage !== 'undefined'
   } catch (error) {
-    return false // should somehow return error instance?
+    // accessing `localStorage` could throw an exception only in one case -
+    // when `localStorage` IS supported, but blocked by security policies
+    return true
   }
 }
 
@@ -58,7 +60,7 @@ function supports() {
 export function local(config?: LocalStorageConfig): StorageAdapter {
   return supports()
     ? storage({
-        storage: localStorage,
+        storage: () => localStorage,
         sync: true,
         ...config,
       })

--- a/src/local/index.ts
+++ b/src/local/index.ts
@@ -6,7 +6,6 @@ import type {
   ConfigJustSourceTarget,
   StorageAdapter,
 } from '../types'
-import type { StorageConfig } from '../storage'
 import { persist as base } from '../core'
 import { nil } from '../nil'
 import { storage } from '../storage'
@@ -17,7 +16,7 @@ export interface ConfigPersist extends BaseConfigPersist {
   sync?: boolean
 }
 
-export interface AdapterConfig {
+export interface LocalStorageConfig {
   sync?: boolean
   serialize?: (value: any) => string
   deserialize?: (value: string) => any
@@ -25,12 +24,12 @@ export interface AdapterConfig {
 }
 
 export interface ConfigStore<State, Err = Error>
-  extends AdapterConfig,
+  extends LocalStorageConfig,
     ConfigCommon<State, Err>,
     ConfigJustStore<State> {}
 
 export interface ConfigSourceTarget<State, Err = Error>
-  extends AdapterConfig,
+  extends LocalStorageConfig,
     ConfigCommon<State, Err>,
     ConfigJustSourceTarget<State> {}
 
@@ -38,8 +37,6 @@ export interface Persist {
   <State, Err = Error>(config: ConfigSourceTarget<State, Err>): Subscription
   <State, Err = Error>(config: ConfigStore<State, Err>): Subscription
 }
-
-export interface LocalStorageConfig extends Omit<StorageConfig, 'storage'> {}
 
 /**
  * Function, checking if `localStorage` exists

--- a/src/nil/README.md
+++ b/src/nil/README.md
@@ -18,6 +18,8 @@ persist({
 
 Note though, that two (or more) different stores, persisted with the same key and same `keyArea`, will be synchronized nonetheless, even if not connected with each other directly — each store will receive updates from another one.
 
+`nil` is "no-op" adapter for [`either`](../tools/README.md#either) function.
+
 ## Adapter
 
 ```javascript

--- a/src/nil/index.ts
+++ b/src/nil/index.ts
@@ -11,5 +11,6 @@ export function nil(keyArea: any = ''): StorageAdapter {
     }
 
   adapter.keyArea = keyArea
+  adapter.noop = true
   return adapter
 }

--- a/src/query/index.ts
+++ b/src/query/index.ts
@@ -25,19 +25,13 @@ export interface ConfigPersist extends BaseConfigPersist {
   state?: StateBehavior
 }
 
-export interface AdapterConfig {
-  method?: ChangeMethod
-  state?: StateBehavior
-  def?: any
-}
-
 export interface ConfigStore<State, Err = Error>
-  extends AdapterConfig,
+  extends QueryConfig,
     ConfigCommon<State, Err>,
     ConfigJustStore<State> {}
 
 export interface ConfigSourceTarget<State, Err = Error>
-  extends AdapterConfig,
+  extends QueryConfig,
     ConfigCommon<State, Err>,
     ConfigJustSourceTarget<State> {}
 

--- a/src/rn/async/index.ts
+++ b/src/rn/async/index.ts
@@ -6,7 +6,6 @@ import type {
   ConfigJustSourceTarget,
   StorageAdapter,
 } from '../../types'
-import type { AsyncStorageConfig as BaseAsyncStorageConfig } from '../../async-storage'
 import { persist as base } from '../../core'
 import { asyncStorage } from '../../async-storage'
 import AsyncStorage from '@react-native-async-storage/async-storage'
@@ -15,18 +14,18 @@ export type { Done, Fail, Finally, StorageAdapter } from '../../types'
 
 export interface ConfigPersist extends BaseConfigPersist {}
 
-export interface AdapterConfig {
+export interface AsyncStorageConfig {
   serialize?: (value: any) => string
   deserialize?: (value: string) => any
 }
 
 export interface ConfigStore<State, Err = Error>
-  extends AdapterConfig,
+  extends AsyncStorageConfig,
     ConfigCommon<State, Err>,
     ConfigJustStore<State> {}
 
 export interface ConfigSourceTarget<State, Err = Error>
-  extends AdapterConfig,
+  extends AsyncStorageConfig,
     ConfigCommon<State, Err>,
     ConfigJustSourceTarget<State> {}
 
@@ -34,9 +33,6 @@ export interface Persist {
   <State, Err = Error>(config: ConfigSourceTarget<State, Err>): Subscription
   <State, Err = Error>(config: ConfigStore<State, Err>): Subscription
 }
-
-export interface AsyncStorageConfig
-  extends Omit<BaseAsyncStorageConfig, 'storage'> {}
 
 /**
  * Creates `AsyncStorage` adapter

--- a/src/rn/async/index.ts
+++ b/src/rn/async/index.ts
@@ -43,7 +43,7 @@ export interface AsyncStorageConfig
  */
 export function async(config: AsyncStorageConfig): StorageAdapter {
   return asyncStorage({
-    storage: AsyncStorage,
+    storage: () => AsyncStorage,
     ...config,
   })
 }

--- a/src/rn/encrypted/index.ts
+++ b/src/rn/encrypted/index.ts
@@ -43,7 +43,7 @@ export interface EncryptedStorageConfig
  */
 export function encrypted(config: EncryptedStorageConfig): StorageAdapter {
   return asyncStorage({
-    storage: EncryptedStorage,
+    storage: () => EncryptedStorage,
     ...config,
   })
 }

--- a/src/rn/encrypted/index.ts
+++ b/src/rn/encrypted/index.ts
@@ -6,7 +6,6 @@ import type {
   ConfigJustSourceTarget,
   StorageAdapter,
 } from '../../types'
-import type { AsyncStorageConfig as BaseAsyncStorageConfig } from '../../async-storage'
 import { persist as base } from '../../core'
 import { asyncStorage } from '../../async-storage'
 import EncryptedStorage from 'react-native-encrypted-storage'
@@ -15,18 +14,18 @@ export type { Done, Fail, Finally, StorageAdapter } from '../../types'
 
 export interface ConfigPersist extends BaseConfigPersist {}
 
-export interface AdapterConfig {
+export interface EncryptedStorageConfig {
   serialize?: (value: any) => string
   deserialize?: (value: string) => any
 }
 
 export interface ConfigStore<State, Err = Error>
-  extends AdapterConfig,
+  extends EncryptedStorageConfig,
     ConfigCommon<State, Err>,
     ConfigJustStore<State> {}
 
 export interface ConfigSourceTarget<State, Err = Error>
-  extends AdapterConfig,
+  extends EncryptedStorageConfig,
     ConfigCommon<State, Err>,
     ConfigJustSourceTarget<State> {}
 
@@ -34,9 +33,6 @@ export interface Persist {
   <State, Err = Error>(config: ConfigSourceTarget<State, Err>): Subscription
   <State, Err = Error>(config: ConfigStore<State, Err>): Subscription
 }
-
-export interface EncryptedStorageConfig
-  extends Omit<BaseAsyncStorageConfig, 'storage'> {}
 
 /**
  * Creates `EncryptedStorage` adapter

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -6,7 +6,6 @@ import type {
   ConfigJustSourceTarget,
   StorageAdapter,
 } from '../types'
-import type { StorageConfig } from '../storage'
 import { persist as base } from '../core'
 import { nil } from '../nil'
 import { storage } from '../storage'
@@ -17,7 +16,7 @@ export interface ConfigPersist extends BaseConfigPersist {
   sync?: boolean
 }
 
-export interface AdapterConfig {
+export interface SessionStorageConfig {
   sync?: boolean
   serialize?: (value: any) => string
   deserialize?: (value: string) => any
@@ -25,12 +24,12 @@ export interface AdapterConfig {
 }
 
 export interface ConfigStore<State, Err = Error>
-  extends AdapterConfig,
+  extends SessionStorageConfig,
     ConfigCommon<State, Err>,
     ConfigJustStore<State> {}
 
 export interface ConfigSourceTarget<State, Err = Error>
-  extends AdapterConfig,
+  extends SessionStorageConfig,
     ConfigCommon<State, Err>,
     ConfigJustSourceTarget<State> {}
 
@@ -38,8 +37,6 @@ export interface Persist {
   <State, Err = Error>(config: ConfigSourceTarget<State, Err>): Subscription
   <State, Err = Error>(config: ConfigStore<State, Err>): Subscription
 }
-
-export interface SessionStorageConfig extends Omit<StorageConfig, 'storage'> {}
 
 /**
  * Function, checking if `sessionStorage` exists

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -42,13 +42,15 @@ export interface Persist {
 export interface SessionStorageConfig extends Omit<StorageConfig, 'storage'> {}
 
 /**
- * Function, checking if `sessionStorage` exists and accessible
+ * Function, checking if `sessionStorage` exists
  */
 function supports() {
   try {
     return typeof sessionStorage !== 'undefined'
   } catch (error) {
-    return false // should somehow return error instance?
+    // accessing `sessionStorage` could throw an exception only in one case -
+    // when `sessionStorage` IS supported, but blocked by security policies
+    return true
   }
 }
 
@@ -58,7 +60,7 @@ function supports() {
 export function session(config?: SessionStorageConfig): StorageAdapter {
   return supports()
     ? storage({
-        storage: sessionStorage,
+        storage: () => sessionStorage,
         ...config,
       })
     : nil('session')

--- a/src/storage/README.md
+++ b/src/storage/README.md
@@ -28,7 +28,7 @@ import { storage } from 'effector-storage/storage'
 
 ### Options
 
-- `storage` ([Storage]): Compatible synchronous storage.
+- `storage` (_() => [Storage]_): Compatible synchronous storage.
 - `sync`? ([_boolean_]): Add [`'storage'`] event listener or no. Default = `false`.
 - `serialize`? (_(value: any) => string_): Custom serialize function. Default = `JSON.stringify`.
 - `deserialize`? (_(value: string) => any_): Custom deserialize function. Default = `JSON.parse`.

--- a/src/tools/README.md
+++ b/src/tools/README.md
@@ -1,0 +1,22 @@
+# Adapter utility functions
+
+## `either`
+
+```javascript
+import { persist, either, local, log } from 'effector-storage'
+
+// - in browser environment will persist
+//   store `$counter` in `localStorage` with key 'counter'
+// - in node environment will just log persist activity
+persist({
+  adapter: either(local(), log()),
+  store: $counter,
+  key: 'counter',
+})
+```
+
+Adapter can be marked as "no-op" using property `noop: true`. If first adapter, given to `either` function, is no-op adapter — `either` function will return second one.
+
+This can be useful with code, which runs in different environments, for example, with server-side rendering same code will run in node, and in browser. There is no `localStorage` support in node, so `local` adapter will be marked as no-op (it will use no-op `nil` adapter under the hood).
+
+Note, that `either` will not fallback to second adapter in case of read/write error in the first one. Second adapter will be used _only_ in case first adapter is not supported within the environment.

--- a/src/tools/either.ts
+++ b/src/tools/either.ts
@@ -1,0 +1,21 @@
+import type { StorageAdapter } from '../types'
+
+/**
+ * Returns first adapter, if it is not noop, and second otherwise.
+ *
+ * In this example,
+ *  - adapter for localStorage will be used in browser environment,
+ *  - logging adapter will be used in node environment
+ *
+ * persist({
+ *   store: $store,
+ *   adapter: either(local(), log()),
+ *   key: 'store'
+ * })
+ */
+export function either(
+  one: StorageAdapter,
+  another: StorageAdapter
+): StorageAdapter {
+  return one.noop ? another : one
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,0 +1,1 @@
+export { either } from './either'

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ export interface StorageAdapter {
     get(value?: any): State | Promise<State>
   }
   keyArea?: any
+  noop?: boolean
 }
 
 export type Done<State> = {

--- a/tests/async-storage.test.ts
+++ b/tests/async-storage.test.ts
@@ -11,7 +11,7 @@ import { createAsyncStorageMock } from './mocks/async-storage.mock'
 //
 
 const mockAsyncStorage = createAsyncStorageMock()
-const asyncStorageAdapter = asyncStorage({ storage: mockAsyncStorage })
+const asyncStorageAdapter = asyncStorage({ storage: () => mockAsyncStorage })
 
 const timeout = (t: number) => new Promise((resolve) => setTimeout(resolve, t))
 
@@ -188,9 +188,9 @@ test('broken store value should launch `catch` handler', async () => {
 
 test('different storage instances should not interfere', async () => {
   const mockStorage1 = createAsyncStorageMock()
-  const storageAdapter1 = asyncStorage({ storage: mockStorage1 })
+  const storageAdapter1 = asyncStorage({ storage: () => mockStorage1 })
   const mockStorage2 = createAsyncStorageMock()
-  const storageAdapter2 = asyncStorage({ storage: mockStorage2 })
+  const storageAdapter2 = asyncStorage({ storage: () => mockStorage2 })
 
   await mockStorage1.setItem('custom', '111')
   await mockStorage2.setItem('custom', '222')
@@ -227,7 +227,7 @@ test('different storage instances should not interfere', async () => {
 test('should be possible to use custom serialization', async () => {
   const mockStorage = createAsyncStorageMock()
   const storageDateAdapter = asyncStorage({
-    storage: mockStorage,
+    storage: () => mockStorage,
     serialize: (date: Date) => String(date.getTime()),
     deserialize: (timestamp: string) => new Date(Number(timestamp)),
   })
@@ -288,11 +288,11 @@ test('should sync stores, persisted to the same adapter-key, but different adapt
   await mockStorage.setItem('same-key-1', '0')
 
   const adapter1 = asyncStorage({
-    storage: mockStorage,
+    storage: () => mockStorage,
     serialize: (value) => String(value),
     deserialize: (value) => Number(value),
   })
-  const adapter2 = asyncStorage({ storage: mockStorage })
+  const adapter2 = asyncStorage({ storage: () => mockStorage })
 
   const $store0 = createStore(1)
   const $store1 = createStore(2)

--- a/tests/clock.test.ts
+++ b/tests/clock.test.ts
@@ -13,7 +13,7 @@ test('should set value to storage only on `clock` trigger', () => {
   const mockStorage = createStorageMock()
   mockStorage.setItem('$store', '0')
 
-  const adapter = storage({ storage: mockStorage })
+  const adapter = storage({ storage: () => mockStorage })
 
   const clock = createEvent()
   const $store = createStore(1, { name: '$store' })

--- a/tests/local-throw.test.ts
+++ b/tests/local-throw.test.ts
@@ -1,6 +1,7 @@
 import { test } from 'uvu'
+import { snoop } from 'snoop'
 import * as assert from 'uvu/assert'
-import { createStore } from 'effector'
+import { createEvent, createStore } from 'effector'
 import { persist } from '../src/local'
 
 //
@@ -27,8 +28,24 @@ test.after(() => {
 //
 
 test('should not fail on forbidden localStorage', async () => {
+  const watch = snoop(() => undefined)
+
+  const fail = createEvent<any>()
+  fail.watch(watch.fn)
+
   const $counter = createStore(0, { name: 'counter' })
-  assert.not.throws(() => persist({ store: $counter }))
+  assert.not.throws(() => persist({ store: $counter, fail }))
+
+  assert.is(watch.callCount, 1)
+  const { error, ...args } = watch.calls[0].arguments[0 as any] as any
+  assert.equal(args, {
+    key: 'counter',
+    keyPrefix: '',
+    operation: 'get',
+    value: undefined,
+  })
+  assert.instance(error, Error)
+  assert.match(error, /Access denied/)
 })
 
 //

--- a/tests/pickup.test.ts
+++ b/tests/pickup.test.ts
@@ -16,7 +16,7 @@ test('should NOT pickup new initial value', () => {
   const mockStorage = createStorageMock()
   mockStorage.setItem('$store', '0')
 
-  const adapter = storage({ storage: mockStorage })
+  const adapter = storage({ storage: () => mockStorage })
 
   const pickup = createEvent()
   const $store = createStore(1, { name: '$store' })
@@ -38,7 +38,7 @@ test('should pickup new value on event', () => {
   const mockStorage = createStorageMock()
   mockStorage.setItem('$store', '42')
 
-  const adapter = storage({ storage: mockStorage })
+  const adapter = storage({ storage: () => mockStorage })
 
   const pickup = createEvent()
   const $store = createStore(1, { name: '$store' })

--- a/tests/session-throw.test.ts
+++ b/tests/session-throw.test.ts
@@ -1,6 +1,7 @@
 import { test } from 'uvu'
+import { snoop } from 'snoop'
 import * as assert from 'uvu/assert'
-import { createStore } from 'effector'
+import { createStore, createEvent } from 'effector'
 import { persist } from '../src/session'
 
 //
@@ -27,8 +28,24 @@ test.after(() => {
 //
 
 test('should not fail on forbidden sessionStorage', async () => {
+  const watch = snoop(() => undefined)
+
+  const fail = createEvent<any>()
+  fail.watch(watch.fn)
+
   const $counter = createStore(0, { name: 'counter' })
-  assert.not.throws(() => persist({ store: $counter }))
+  assert.not.throws(() => persist({ store: $counter, fail }))
+
+  assert.is(watch.callCount, 1)
+  const { error, ...args } = watch.calls[0].arguments[0 as any] as any
+  assert.equal(args, {
+    key: 'counter',
+    keyPrefix: '',
+    operation: 'get',
+    value: undefined,
+  })
+  assert.instance(error, Error)
+  assert.match(error, /Access denied/)
 })
 
 //

--- a/tests/storage-sync.test.ts
+++ b/tests/storage-sync.test.ts
@@ -21,7 +21,7 @@ let events: ReturnType<typeof createEventsMock>
 test.before(() => {
   events = createEventsMock()
   global.addEventListener = events.addEventListener
-  storageAdapter = storage({ storage: mockStorage, sync: true })
+  storageAdapter = storage({ storage: () => mockStorage, sync: true })
 })
 
 test.after(() => {
@@ -98,7 +98,7 @@ test('persisted store should ignore updates from different storage', async () =>
 
 test('persisted store should be erased on storage.clear()', async () => {
   const mockStorage = createStorageMock()
-  const storageAdapter = storage({ storage: mockStorage, sync: true })
+  const storageAdapter = storage({ storage: () => mockStorage, sync: true })
 
   const $counter4 = createStore(0, { name: 'counter4' })
   persist({ store: $counter4, adapter: storageAdapter })
@@ -118,7 +118,7 @@ test('persisted store should be restored to default value on storage.clear()', a
   mockStorage.setItem('counter5', '42')
 
   const $counter5 = createStore(0, { name: 'counter5' })
-  const adapter = storage({ storage: mockStorage, sync: true, def: 21 })
+  const adapter = storage({ storage: () => mockStorage, sync: true, def: 21 })
   persist({ store: $counter5, adapter })
   assert.is($counter5.getState(), 42) // <- restore value from storage
 

--- a/tests/storage.test.ts
+++ b/tests/storage.test.ts
@@ -11,7 +11,7 @@ import { createStorageMock } from './mocks/storage.mock'
 //
 
 const mockStorage = createStorageMock()
-const storageAdapter = storage({ storage: mockStorage })
+const storageAdapter = storage({ storage: () => mockStorage })
 
 //
 // Tests
@@ -56,7 +56,7 @@ test('store should be initialized from storage value', () => {
 
 test('store should be initialized with default value', () => {
   const $counter31 = createStore(0, { name: 'counter31' })
-  const adapter = storage({ storage: mockStorage, def: 42 })
+  const adapter = storage({ storage: () => mockStorage, def: 42 })
   persist({ store: $counter31, adapter })
   assert.is(mockStorage.getItem('counter31'), null)
   assert.is($counter31.getState(), 42)
@@ -64,7 +64,7 @@ test('store should be initialized with default value', () => {
 
 test('store should be initialized from storage value, not default value', () => {
   mockStorage.setItem('counter32', '42')
-  const adapter = storage({ storage: mockStorage, def: 21 })
+  const adapter = storage({ storage: () => mockStorage, def: 21 })
   const $counter32 = createStore(0, { name: 'counter32' })
   persist({ store: $counter32, adapter })
   assert.is(mockStorage.getItem('counter32'), '42')
@@ -185,9 +185,9 @@ test('broken store value should launch `catch` handler', () => {
 
 test('different storage instances should not interfere', () => {
   const mockStorage1 = createStorageMock()
-  const storageAdapter1 = storage({ storage: mockStorage1 })
+  const storageAdapter1 = storage({ storage: () => mockStorage1 })
   const mockStorage2 = createStorageMock()
-  const storageAdapter2 = storage({ storage: mockStorage2 })
+  const storageAdapter2 = storage({ storage: () => mockStorage2 })
 
   mockStorage1.setItem('custom', '111')
   mockStorage2.setItem('custom', '222')
@@ -220,7 +220,7 @@ test('different storage instances should not interfere', () => {
 test('should be possible to use custom serialization', () => {
   const mockStorage = createStorageMock()
   const storageDateAdapter = storage({
-    storage: mockStorage,
+    storage: () => mockStorage,
     sync: false,
     serialize: (date: Date) => String(date.getTime()),
     deserialize: (timestamp: string) => new Date(Number(timestamp)),
@@ -274,8 +274,8 @@ test('should sync stores, persisted to the same adapter-key, but different adapt
   const mockStorage = createStorageMock()
   mockStorage.setItem('same-key-1', '0')
 
-  const adapter1 = storage({ storage: mockStorage, sync: false })
-  const adapter2 = storage({ storage: mockStorage, sync: true })
+  const adapter1 = storage({ storage: () => mockStorage, sync: false })
+  const adapter2 = storage({ storage: () => mockStorage, sync: true })
 
   const $store0 = createStore(1)
   const $store1 = createStore(2)

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -1,0 +1,60 @@
+import type { StorageAdapter } from '../src/types'
+import { test } from 'uvu'
+import * as assert from 'uvu/assert'
+import { createStorageMock } from './mocks/storage.mock'
+import { local } from '../src/local'
+import { nil } from '../src/nil'
+import { either } from '../src/tools'
+
+declare let global: any
+
+//
+// Dumb fake adapter
+//
+
+const dumbAdapter: StorageAdapter = <T>() => {
+  let __: T = 0 as any
+  return {
+    get: (): T => __,
+    set: (value: T) => (__ = value),
+  }
+}
+
+//
+// Tests
+//
+
+test('should return first adapter if first one is not noop', () => {
+  const one = dumbAdapter
+  const another = nil()
+  assert.equal(either(one, another), one)
+})
+
+test('should return second adapter if first one is noop', () => {
+  const one = nil()
+  const another = dumbAdapter
+  assert.equal(either(one, another), another)
+})
+
+test('should return localStorage adapter if localStorage is supported', () => {
+  try {
+    global.localStorage = createStorageMock()
+    const one = local()
+    const another = dumbAdapter
+    assert.equal(either(one, another), one)
+  } finally {
+    delete global.localStorage
+  }
+})
+
+test('should return second adapter if localStorage is not supported', () => {
+  const one = local()
+  const another = dumbAdapter
+  assert.equal(either(one, another), another)
+})
+
+//
+// Launch tests
+//
+
+test.run()


### PR DESCRIPTION
Addresses issue #35 

This PR adds two changes:

1. Separates terms "supported" and "available" for adapters

Previously, if `localStorage` was disabled by browser's security policies, `local` adapter just did nothing. like `localStorage` doesn't exists.

Now, `local` adapter separates cases, when `localStorage` is not supported (not exists, for example, in Node environment), then adapter does nothing. And when `localStorage` is supported (exists), but disabled by security policies — adapter will trigger errors on each read/write operation. Errors could be handled by `fail` event, as usual.

**This is breaking change**.

2. Adds `either` utility function

Given two adapters, this function will return first one, either second one, if first one is "no-op" adapter, meaning "not supported" / "does nothing". For example, `nil` adapter is no-op adapter. `local` adapter in Node environment is no-op adapter.