### PR TITLE
Add `sync = 'force'` mode for storage adapter

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -10,7 +10,7 @@ module.exports = [
   {
     name: 'root persist, cjs module',
     path: 'build/index.cjs',
-    limit: '2647 B',
+    limit: '2656 B',
     // import: '{ persist }', // tree-shaking is not working with cjs
     ignore: ['effector'],
   },
@@ -43,7 +43,7 @@ module.exports = [
     name: 'tools, cjs module',
     path: 'build/tools/index.cjs',
     limit: '509 B',
-    // import: '{ async, either }', // tree-shaking is not working with cjs
+    // import: '{ async, either, farcached }', // tree-shaking is not working with cjs
     ignore: ['effector'],
   },
 
@@ -83,14 +83,14 @@ module.exports = [
   {
     name: 'storage adapter, es module',
     path: 'build/storage/index.js',
-    limit: '256 B',
+    limit: '266 B',
     import: '{ storage }',
     ignore: ['effector'],
   },
   {
     name: 'storage adapter, cjs module',
     path: 'build/storage/index.cjs',
-    limit: '312 B',
+    limit: '324 B',
     // import: '{ storage }', // tree-shaking is not working with cjs
     ignore: ['effector'],
   },
@@ -99,14 +99,14 @@ module.exports = [
   {
     name: '`localStorage` persist, es module',
     path: 'build/local/index.js',
-    limit: '1246 B',
+    limit: '1254 B',
     import: '{ persist }',
     ignore: ['effector'],
   },
   {
     name: '`localStorage` persist, cjs module',
     path: 'build/local/index.cjs',
-    limit: '1518 B',
+    limit: '1529 B',
     // import: '{ persist }', // tree-shaking is not working with cjs
     ignore: ['effector'],
   },
@@ -116,14 +116,14 @@ module.exports = [
   {
     name: 'core adapter, es module',
     path: 'build/index.js',
-    limit: '1252 B',
+    limit: '1261 B',
     import: '{ persist, local }',
     ignore: ['effector'],
   },
   {
     name: 'core adapter factory, es module',
     path: ['build/index.js', 'build/local/index.js'],
-    limit: '1254 B',
+    limit: '1264 B',
     import: {
       'build/index.js': '{ persist }',
       'build/local/index.js': '{ local }',
@@ -135,14 +135,14 @@ module.exports = [
   {
     name: '`sessionStorage` persist, es module',
     path: 'build/session/index.js',
-    limit: '1243 B',
+    limit: '1252 B',
     import: '{ persist }',
     ignore: ['effector'],
   },
   {
     name: '`sessionStorage` persist, cjs module',
     path: 'build/session/index.cjs',
-    limit: '1515 B',
+    limit: '1526 B',
     // import: '{ persist }', // tree-shaking is not working with cjs
     ignore: ['effector'],
   },

--- a/README.md
+++ b/README.md
@@ -458,7 +458,7 @@ adapter = storage(options)
 #### Options
 
 - `storage` (_Storage_): Storage to communicate with.
-- `sync`? ([_boolean_]): Add [`'storage'`] event listener or no. Default = `false`.
+- `sync`? ([_boolean_] | 'force'): Add [`'storage'`] event listener or no. Default = `false`. In case of `'force'` value adapter will always read new value from _Storage_, instead of event.
 - `serialize`? (_(value: any) => string_): Custom serialize function. Default = `JSON.stringify`
 - `deserialize`? (_(value: string) => any_): Custom deserialize function. Default = `JSON.parse`
 

--- a/src/local/README.md
+++ b/src/local/README.md
@@ -32,7 +32,7 @@ import { persist } from 'effector-storage/local'
 ### Options
 
 - ... all the [common options](../../README.md#options) from root `persist` function.
-- `sync`? ([_boolean_]): Add [`'storage'`] event listener or no. Default = `true`.
+- `sync`? ([_boolean_] | 'force'): Add [`'storage'`] event listener or no. Default = `true`. In case of `'force'` value adapter will always read new value from `localStorage`, instead of event.
 - `serialize`? (_(value: any) => string_): Custom serialize function. Default = `JSON.stringify`.
 - `deserialize`? (_(value: string) => any_): Custom deserialize function. Default = `JSON.parse`.
 
@@ -52,7 +52,7 @@ import { local } from 'effector-storage/local'
 
 ### Options
 
-- `sync`? ([_boolean_]): Add [`'storage'`] event listener or no. Default = `true`.
+- `sync`? ([_boolean_] | 'force'): Add [`'storage'`] event listener or no. Default = `true`. In case of `'force'` value adapter will always read new value from `localStorage`, instead of event.
 - `serialize`? (_(value: any) => string_): Custom serialize function. Default = `JSON.stringify`.
 - `deserialize`? (_(value: string) => any_): Custom deserialize function. Default = `JSON.parse`.
 - `def`?: (_any_): Default value, which will be passed to `store`/`target` in case of absent storage value. Default = `store.defaultState` or `null`.

--- a/src/local/index.ts
+++ b/src/local/index.ts
@@ -19,11 +19,11 @@ export type {
 } from '../types'
 
 export interface ConfigPersist extends BaseConfigPersist {
-  sync?: boolean
+  sync?: boolean | 'force'
 }
 
 export interface LocalStorageConfig {
-  sync?: boolean
+  sync?: boolean | 'force'
   serialize?: (value: any) => string
   deserialize?: (value: string) => any
   def?: any

--- a/src/session/README.md
+++ b/src/session/README.md
@@ -30,7 +30,7 @@ import { persist } from 'effector-storage/session'
 ### Options
 
 - ... all the [common options](../../README.md#options) from `persist` function.
-- `sync`? ([_boolean_]): Add [`'storage'`] event listener or no. Default = `false`.
+- `sync`? ([_boolean_] | 'force'): Add [`'storage'`] event listener or no. Default = `false`. In case of `'force'` value adapter will always read new value from `sessionStorage`, instead of event.
 - `serialize`? (_(value: any) => string_): Custom serialize function. Default = `JSON.stringify`.
 - `deserialize`? (_(value: string) => any_): Custom deserialize function. Default = `JSON.parse`.
 - `def`?: (_any_): Default value, which will be passed to `store`/`target` in case of absent storage value. Default = `store.defaultState` or `null`.
@@ -51,7 +51,7 @@ import { session } from 'effector-storage/session'
 
 ### Options
 
-- `sync`? ([_boolean_]): Add [`'storage'`] event listener or no. Default = `false`.
+- `sync`? ([_boolean_] | 'force'): Add [`'storage'`] event listener or no. Default = `false`. In case of `'force'` value adapter will always read new value from `sessionStorage`, instead of event.
 - `serialize`? (_(value: any) => string_): Custom serialize function. Default = `JSON.stringify`.
 - `deserialize`? (_(value: string) => any_): Custom deserialize function. Default = `JSON.parse`.
 

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -19,11 +19,11 @@ export type {
 } from '../types'
 
 export interface ConfigPersist extends BaseConfigPersist {
-  sync?: boolean
+  sync?: boolean | 'force'
 }
 
 export interface SessionStorageConfig {
-  sync?: boolean
+  sync?: boolean | 'force'
   serialize?: (value: any) => string
   deserialize?: (value: string) => any
   def?: any

--- a/src/storage/README.md
+++ b/src/storage/README.md
@@ -35,7 +35,7 @@ import { storage } from 'effector-storage/storage'
 ### Options
 
 - `storage` (_() => [Storage]_): Compatible synchronous storage.
-- `sync`? ([_boolean_]): Add [`'storage'`] event listener or no. Default = `false`.
+- `sync`? ([_boolean_] | 'force'): Add [`'storage'`] event listener or no. Default = `false`. In case of `'force'` value adapter will always read new value from _Storage_, instead of event.
 - `serialize`? (_(value: any) => string_): Custom serialize function. Default = `JSON.stringify`.
 - `deserialize`? (_(value: string) => any_): Custom deserialize function. Default = `JSON.parse`.
 - `def`?: (_any_): Default value, which will be passed to `store`/`target` in case of absent storage value. Default = `store.defaultState` or `null`.

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -2,7 +2,7 @@ import type { StorageAdapter } from '../types'
 
 export interface StorageConfig {
   storage: () => Storage
-  sync?: boolean
+  sync?: boolean | 'force'
   serialize?: (value: any) => string
   deserialize?: (value: string) => any
   def?: any
@@ -29,7 +29,7 @@ export function storage({
         // so calling `storage()` should not throw security exception here
         if (e.storageArea === storage()) {
           // call `get` function with new value
-          if (e.key === key) update(e.newValue)
+          if (e.key === key) update(sync === 'force' ? undefined : e.newValue)
 
           // `key` attribute is `null` when the change is caused by the storage `clear()` method
           if (e.key === null) update(null)

--- a/tests/storage-sync.test.ts
+++ b/tests/storage-sync.test.ts
@@ -131,6 +131,25 @@ test('persisted store should be restored to default value on storage.clear()', a
   assert.is($counter5.getState(), 21) // <- default value from adapter
 })
 
+test('persisted store should be force updated from storage', async () => {
+  const $counter6 = createStore(0, { name: 'counter6' })
+  persist({
+    store: $counter6,
+    adapter: storage({ storage: () => mockStorage, sync: 'force' }),
+  })
+  assert.is($counter6.getState(), 0)
+
+  mockStorage.setItem('counter6', '42')
+  await events.dispatchEvent('storage', {
+    storageArea: mockStorage,
+    key: 'counter6',
+    oldValue: null,
+    newValue: '13', // <- should be ignored as obsolete value and `force` is enabled
+  })
+
+  assert.is($counter6.getState(), 42) // <- should read value from storage
+})
+
 //
 // Launch tests
 //


### PR DESCRIPTION
This should fix stores desynchronization with simultaneous or almost simultaneous updates from different tabs.
See issue #32 for more details.