### PR TITLE
Remove listeners on desist

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -3,7 +3,7 @@ module.exports = [
   {
     name: 'root persist, es module',
     path: 'build/index.js',
-    limit: '963 B',
+    limit: '985 B',
     import: '{ persist }',
     ignore: ['effector'],
     gzip: true,
@@ -11,7 +11,7 @@ module.exports = [
   {
     name: 'root persist, cjs module',
     path: 'build/index.cjs',
-    limit: '3151 B',
+    limit: '3250 B',
     // import: '{ persist }', // tree-shaking is not working with cjs
     ignore: ['effector'],
     gzip: true,
@@ -21,7 +21,7 @@ module.exports = [
   {
     name: 'core persist, es module',
     path: 'build/core/index.js',
-    limit: '958 B',
+    limit: '980 B',
     import: '{ persist }',
     ignore: ['effector'],
     gzip: true,
@@ -29,7 +29,7 @@ module.exports = [
   {
     name: 'core persist, cjs module',
     path: 'build/core/index.cjs',
-    limit: '1145 B',
+    limit: '1166 B',
     // import: '{ persist }', // tree-shaking is not working with cjs
     ignore: ['effector'],
     gzip: true,
@@ -93,7 +93,7 @@ module.exports = [
   {
     name: 'storage adapter, es module',
     path: 'build/storage/index.js',
-    limit: '358 B',
+    limit: '399 B',
     import: '{ storage }',
     ignore: ['effector'],
     gzip: true,
@@ -101,7 +101,7 @@ module.exports = [
   {
     name: 'storage adapter, cjs module',
     path: 'build/storage/index.cjs',
-    limit: '415 B',
+    limit: '460 B',
     // import: '{ storage }', // tree-shaking is not working with cjs
     ignore: ['effector'],
     gzip: true,
@@ -111,7 +111,7 @@ module.exports = [
   {
     name: '`localStorage` persist, es module',
     path: 'build/local/index.js',
-    limit: '1393 B',
+    limit: '1453 B',
     import: '{ persist }',
     ignore: ['effector'],
     gzip: true,
@@ -119,7 +119,7 @@ module.exports = [
   {
     name: '`localStorage` persist, cjs module',
     path: 'build/local/index.cjs',
-    limit: '1670 B',
+    limit: '1732 B',
     // import: '{ persist }', // tree-shaking is not working with cjs
     ignore: ['effector'],
     gzip: true,
@@ -130,7 +130,7 @@ module.exports = [
   {
     name: 'core adapter, es module',
     path: 'build/index.js',
-    limit: '1399 B',
+    limit: '1459 B',
     import: '{ persist, local }',
     ignore: ['effector'],
     gzip: true,
@@ -138,7 +138,7 @@ module.exports = [
   {
     name: 'core adapter factory, es module',
     path: ['build/index.js', 'build/local/index.js'],
-    limit: '1402 B',
+    limit: '1462 B',
     import: {
       'build/index.js': '{ persist }',
       'build/local/index.js': '{ local }',
@@ -151,7 +151,7 @@ module.exports = [
   {
     name: '`sessionStorage` persist, es module',
     path: 'build/session/index.js',
-    limit: '1387 B',
+    limit: '1451 B',
     import: '{ persist }',
     ignore: ['effector'],
     gzip: true,
@@ -159,7 +159,7 @@ module.exports = [
   {
     name: '`sessionStorage` persist, cjs module',
     path: 'build/session/index.cjs',
-    limit: '1668 B',
+    limit: '1729 B',
     // import: '{ persist }', // tree-shaking is not working with cjs
     ignore: ['effector'],
     gzip: true,
@@ -169,7 +169,7 @@ module.exports = [
   {
     name: 'query string persist, es module',
     path: 'build/query/index.js',
-    limit: '1452 B',
+    limit: '1509 B',
     import: '{ persist }',
     ignore: ['effector'],
     gzip: true,
@@ -177,7 +177,7 @@ module.exports = [
   {
     name: 'query string persist, cjs module',
     path: 'build/query/index.cjs',
-    limit: '1749 B',
+    limit: '1802 B',
     // import: '{ persist }', // tree-shaking is not working with cjs
     ignore: ['effector'],
     gzip: true,
@@ -187,7 +187,7 @@ module.exports = [
   {
     name: 'memory adapter, es module',
     path: 'build/memory/index.js',
-    limit: '1051 B',
+    limit: '1073 B',
     import: '{ persist }',
     ignore: ['effector'],
     gzip: true,
@@ -195,7 +195,7 @@ module.exports = [
   {
     name: 'memory adapter, cjs module',
     path: 'build/memory/index.cjs',
-    limit: '1284 B',
+    limit: '1304 B',
     // import: '{ persist }', // tree-shaking is not working with cjs
     ignore: ['effector'],
     gzip: true,
@@ -223,7 +223,7 @@ module.exports = [
   {
     name: 'broadcast channel adapter, es module',
     path: 'build/broadcast/index.js',
-    limit: '1260 B',
+    limit: '1317 B',
     import: '{ broadcast }',
     ignore: ['effector'],
     gzip: true,
@@ -231,7 +231,7 @@ module.exports = [
   {
     name: 'broadcast channel adapter, cjs module',
     path: 'build/broadcast/index.cjs',
-    limit: '1514 B',
+    limit: '1568 B',
     // import: '{ broadcast }', // tree-shaking is not working with cjs
     ignore: ['effector'],
     gzip: true,

--- a/src/broadcast/index.ts
+++ b/src/broadcast/index.ts
@@ -15,6 +15,8 @@ export type {
   Done,
   Fail,
   Finally,
+  Adapter,
+  DisposableAdapter,
   StorageAdapter,
   StorageAdapterFactory,
 } from '../types'

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -109,7 +109,8 @@ export function persist<State, Err = Error>(
     keyPrefix + key
   )
   const region = createNode()
-  const desist = () => clearNode(region)
+  let disposable: (_: any) => void = () => {}
+  const desist = () => disposable(clearNode(region))
 
   const op =
     (operation: 'get' | 'set' | 'validate') =>
@@ -139,6 +140,10 @@ export function persist<State, Err = Error>(
     const value = adapter<State>(keyPrefix + key, (x) => {
       update(x)
     })
+
+    if (typeof value === 'function') {
+      disposable = value
+    }
 
     const getFx = attach({
       source: ctx,

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,8 @@ export type {
   Fail,
   Finally,
   Persist,
+  Adapter,
+  DisposableAdapter,
   StorageAdapter,
   StorageAdapterFactory,
 } from './types'

--- a/src/local/index.ts
+++ b/src/local/index.ts
@@ -14,6 +14,8 @@ export type {
   Done,
   Fail,
   Finally,
+  Adapter,
+  DisposableAdapter,
   StorageAdapter,
   StorageAdapterFactory,
 } from '../types'

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -12,6 +12,8 @@ export type {
   Done,
   Fail,
   Finally,
+  Adapter,
+  DisposableAdapter,
   StorageAdapter,
   StorageAdapterFactory,
 } from '../types'

--- a/src/query/adapter.ts
+++ b/src/query/adapter.ts
@@ -77,11 +77,19 @@ export function adapter({
     key: string,
     update: (raw?: any) => void
   ) => {
+    const updated = () => setTimeout(update, 0)
+
     if (typeof addEventListener !== 'undefined') {
-      addEventListener('popstate', () => setTimeout(update, 0))
+      addEventListener('popstate', updated)
     }
 
-    return {
+    const dispose = () => {
+      if (typeof removeEventListener !== 'undefined') {
+        removeEventListener('popstate', updated)
+      }
+    }
+
+    return Object.assign(dispose, {
       get() {
         const params = new URLSearchParams(location.search)
         const value = params.get(key)
@@ -103,7 +111,7 @@ export function adapter({
           timeoutId = setTimeout(flush, timeout, method, state)
         }
       },
-    }
+    })
   }
 
   adapter.keyArea = keyArea

--- a/src/query/index.ts
+++ b/src/query/index.ts
@@ -15,6 +15,8 @@ export type {
   Done,
   Fail,
   Finally,
+  Adapter,
+  DisposableAdapter,
   StorageAdapter,
   StorageAdapterFactory,
 } from '../types'

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -14,6 +14,8 @@ export type {
   Done,
   Fail,
   Finally,
+  Adapter,
+  DisposableAdapter,
   StorageAdapter,
   StorageAdapterFactory,
 } from '../types'

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,13 +1,19 @@
 import type { Event, Effect, Store, Unit, Subscription } from 'effector'
 
+export interface Adapter<State> {
+  get(raw?: any, ctx?: any): State | Promise<State | undefined> | undefined
+  set(value: State, ctx?: any): void
+}
+
+export interface DisposableAdapter<State> extends Adapter<State> {
+  (): void
+}
+
 export interface StorageAdapter {
   <State>(
     key: string,
     update: (raw?: any) => void
-  ): {
-    get(raw?: any, ctx?: any): State | Promise<State | undefined> | undefined
-    set(value: State, ctx?: any): void
-  }
+  ): Adapter<State> | DisposableAdapter<State>
   keyArea?: any
   noop?: boolean
 }

--- a/tests/adapters.test.ts
+++ b/tests/adapters.test.ts
@@ -2,7 +2,7 @@ import { test } from 'uvu'
 import * as assert from 'uvu/assert'
 import { createStore } from 'effector'
 import { createStorageMock } from './mocks/storage.mock'
-import { createEventsMock } from './mocks/events.mock'
+import { type Events, createEventsMock } from './mocks/events.mock'
 import { createHistoryMock } from './mocks/history.mock'
 import { createLocationMock } from './mocks/location.mock'
 import { persist } from '../src/core'
@@ -15,7 +15,7 @@ import { query } from '../src/query'
 //
 
 declare let global: any
-let events: ReturnType<typeof createEventsMock>
+let events: Events
 
 test.before(() => {
   global.localStorage = createStorageMock()

--- a/tests/broadcast-desist.test.ts
+++ b/tests/broadcast-desist.test.ts
@@ -1,0 +1,89 @@
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference
+/// <reference types="node" />
+
+import { test } from 'uvu'
+import { snoop } from 'snoop'
+import * as assert from 'uvu/assert'
+import { createEffect, createStore } from 'effector'
+import { createEventsMock } from './mocks/events.mock'
+import { persist } from '../src/broadcast'
+
+//
+// Mock events
+//
+
+declare let global: any
+
+//
+// Tests
+//
+
+test('should stop react on `message` and `messageerror` after desist', async () => {
+  const _BroadcastChannel = global.BroadcastChannel
+  const events = createEventsMock()
+  const addListener = snoop(events.addEventListener)
+  const removeListener = snoop(events.removeEventListener)
+
+  global.BroadcastChannel = class BroadcastChannelMock {
+    public name: string
+
+    constructor(name: string) {
+      this.name = name
+    }
+
+    addEventListener(name: string, listener: EventListener) {
+      return addListener.fn(name, listener)
+    }
+
+    removeEventListener(name: string, listener: EventListener) {
+      return removeListener.fn(name, listener)
+    }
+  }
+
+  try {
+    const watch = snoop(() => undefined)
+
+    const $test = createStore('')
+    const desist = persist({
+      store: $test,
+      key: 'test-desist',
+      channel: 'test-desist',
+      done: createEffect<any, any>(watch.fn),
+      fail: createEffect<any, any>(watch.fn),
+    })
+
+    assert.is(addListener.callCount, 2)
+    assert.equal(addListener.calls[0].arguments[0], 'message')
+    assert.equal(addListener.calls[1].arguments[0], 'messageerror')
+
+    const messageListener = addListener.calls[0].arguments[1]
+    const messageerrorListener = addListener.calls[1].arguments[1]
+
+    assert.is(watch.callCount, 1) // <- initial get call
+
+    // stop persisting
+    desist()
+
+    assert.is(addListener.callCount, 2) // <- not changed
+    assert.is(removeListener.callCount, 2)
+    assert.equal(removeListener.calls[0].arguments[0], 'message')
+    assert.equal(removeListener.calls[1].arguments[0], 'messageerror')
+
+    assert.is(addListener.calls[0].arguments[1], messageListener)
+    assert.is(addListener.calls[1].arguments[1], messageerrorListener)
+
+    await events.dispatchEvent('message', { data: null })
+    assert.is(watch.callCount, 1) // <- not changed
+
+    await events.dispatchEvent('messageerror', { data: null })
+    assert.is(watch.callCount, 1) // <- not changed
+  } finally {
+    global.BroadcastChannel = _BroadcastChannel
+  }
+})
+
+//
+// Launch tests
+//
+
+test.run()

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -8,7 +8,7 @@ import { runtypeContract } from '@farfetched/runtypes'
 import { persist } from '../src/core'
 import { storage } from '../src/storage'
 import { createStorageMock } from './mocks/storage.mock'
-import { createEventsMock } from './mocks/events.mock'
+import { type Events, createEventsMock } from './mocks/events.mock'
 
 //
 // Mock abstract Storage adapter
@@ -18,7 +18,7 @@ declare let global: any
 
 const mockStorage = createStorageMock()
 let storageAdapter: StorageAdapter
-let events: ReturnType<typeof createEventsMock>
+let events: Events
 
 test.before(() => {
   events = createEventsMock()

--- a/tests/local-create.test.ts
+++ b/tests/local-create.test.ts
@@ -2,7 +2,7 @@ import { test } from 'uvu'
 import * as assert from 'uvu/assert'
 import { createStore } from 'effector'
 import { createStorageMock } from './mocks/storage.mock'
-import { createEventsMock } from './mocks/events.mock'
+import { type Events, createEventsMock } from './mocks/events.mock'
 import { createPersist } from '../src/local'
 
 //
@@ -10,7 +10,7 @@ import { createPersist } from '../src/local'
 //
 
 declare let global: any
-let events: ReturnType<typeof createEventsMock>
+let events: Events
 
 test.before(() => {
   global.localStorage = createStorageMock()

--- a/tests/local-desist.test.ts
+++ b/tests/local-desist.test.ts
@@ -1,0 +1,154 @@
+import { test } from 'uvu'
+import * as assert from 'uvu/assert'
+import { type Snoop, snoop } from 'snoop'
+import { createStore } from 'effector'
+import { createStorageMock } from './mocks/storage.mock'
+import {
+  type Events,
+  createEventsMock,
+  type EventsMock,
+} from './mocks/events.mock'
+import { persist } from '../src/local'
+
+//
+// Mock `localStorage` and events
+//
+
+declare let global: any
+let events: EventsMock
+let addListener: Snoop<Events['addEventListener']>
+let removeListener: Snoop<Events['removeEventListener']>
+
+test.before.each(() => {
+  global.localStorage = createStorageMock()
+  events = createEventsMock() as EventsMock
+
+  addListener = snoop(events.addEventListener)
+  global.addEventListener = addListener.fn
+
+  removeListener = snoop(events.removeEventListener)
+  global.removeEventListener = removeListener.fn
+})
+
+test.after.each(() => {
+  delete global.localStorage
+  delete global.addEventListener
+  delete global.removeEventListener
+})
+
+//
+// Tests
+//
+
+test('should stop persisting on desist', async () => {
+  const $counter = createStore(0, { name: 'counter' })
+  const desist = persist({ store: $counter })
+
+  // update via `storage` event
+  global.localStorage.setItem('counter', '1')
+  await events.dispatchEvent('storage', {
+    storageArea: global.localStorage,
+    key: 'counter',
+    oldValue: null,
+    newValue: '1',
+  })
+  assert.is($counter.getState(), 1)
+
+  // update storage via store change
+  ;($counter as any).setState(2)
+  assert.is(global.localStorage.getItem('counter'), '2')
+
+  // stop persisting
+  desist()
+
+  // should not update storage via store change
+  ;($counter as any).setState(3)
+  assert.is(global.localStorage.getItem('counter'), '2') // <- not updated
+
+  // should not update store via `storage` event
+  global.localStorage.setItem('counter', '4')
+  await events.dispatchEvent('storage', {
+    storageArea: global.localStorage,
+    key: 'counter',
+    oldValue: '2',
+    newValue: '4',
+  })
+  assert.is($counter.getState(), 3) // <- not updated
+})
+
+test('should remove `storage` event listener on desist', async () => {
+  const $counter = createStore(0, { name: 'counter' })
+  const desist = persist({ store: $counter })
+
+  assert.is(addListener.callCount, 1)
+  assert.equal(addListener.calls[0].arguments[0], 'storage')
+  const listener = addListener.calls[0].arguments[1]
+
+  assert.is(events.listeners.size, 1)
+  assert.is(events.listeners.get('storage')?.length, 1)
+
+  // stop persisting
+  desist()
+
+  assert.is(removeListener.callCount, 1)
+  assert.equal(removeListener.calls[0].arguments[0], 'storage')
+  assert.is(removeListener.calls[0].arguments[1], listener)
+
+  assert.is(events.listeners.size, 1)
+  assert.is(events.listeners.get('storage')?.length, 0)
+})
+
+test('should not remove other store `storage` event listener on desist', async () => {
+  const $counter1 = createStore(0, { name: 'counter' })
+  const desist1 = persist({ store: $counter1 })
+
+  assert.is(addListener.callCount, 1)
+  assert.equal(addListener.calls[0].arguments[0], 'storage')
+  const listener1 = addListener.calls[0].arguments[1]
+
+  const $counter2 = createStore(0, { name: 'counter' })
+  persist({ store: $counter2 })
+
+  assert.is(addListener.callCount, 2)
+  assert.equal(addListener.calls[1].arguments[0], 'storage')
+  const listener2 = addListener.calls[1].arguments[1]
+
+  assert.is.not(listener1, listener2)
+
+  assert.is(events.listeners.size, 1)
+  assert.is(events.listeners.get('storage')?.length, 2)
+  assert.is(events.listeners.get('storage')?.[0], listener1)
+  assert.is(events.listeners.get('storage')?.[1], listener2)
+
+  // stop persisting
+  desist1()
+
+  assert.is(removeListener.callCount, 1)
+  assert.equal(removeListener.calls[0].arguments[0], 'storage')
+  assert.is(removeListener.calls[0].arguments[1], listener1)
+
+  assert.is(events.listeners.size, 1)
+  assert.is(events.listeners.get('storage')?.length, 1)
+  assert.is(events.listeners.get('storage')?.[0], listener2)
+})
+
+test('should flush unsaved changes on desist', async () => {
+  const $counter = createStore(0, { name: 'counter' })
+  const desist = persist({ store: $counter, timeout: 100 })
+
+  //
+  ;($counter as any).setState(1)
+  assert.is($counter.getState(), 1)
+  assert.is(global.localStorage.getItem('counter'), null) // <- not changed yet
+
+  // stop persisting
+  desist()
+
+  assert.is(global.localStorage.getItem('counter'), '1') // changed immediately
+})
+
+//
+// Launch tests
+//
+
+test.run()

--- a/tests/local.test.ts
+++ b/tests/local.test.ts
@@ -3,7 +3,7 @@ import * as assert from 'uvu/assert'
 import { snoop } from 'snoop'
 import { createEvent, createStore } from 'effector'
 import { createStorageMock } from './mocks/storage.mock'
-import { createEventsMock } from './mocks/events.mock'
+import { type Events, createEventsMock } from './mocks/events.mock'
 import { local, persist } from '../src/local'
 
 //
@@ -11,7 +11,7 @@ import { local, persist } from '../src/local'
 //
 
 declare let global: any
-let events: ReturnType<typeof createEventsMock>
+let events: Events
 
 test.before(() => {
   global.localStorage = createStorageMock()

--- a/tests/mocks/events.mock.ts
+++ b/tests/mocks/events.mock.ts
@@ -1,15 +1,15 @@
-interface EventListener {
+export interface EventListener {
   (event: any): void
 }
 
-interface Events {
+export interface Events {
   dispatchEvent(name: string, event: any): Promise<any>
   addEventListener(name: string, listener: EventListener): void
   removeEventListener(name: string, listener: EventListener): void
 }
 
 export class EventsMock implements Events {
-  private listeners = new Map<string, EventListener[]>()
+  public listeners = new Map<string, EventListener[]>()
 
   public async dispatchEvent(
     name: string,

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -3,7 +3,7 @@ import * as assert from 'uvu/assert'
 import { snoop } from 'snoop'
 import { createEvent, createStore } from 'effector'
 import { createStorageMock } from './mocks/storage.mock'
-import { createEventsMock } from './mocks/events.mock'
+import { type Events, createEventsMock } from './mocks/events.mock'
 import { session, persist } from '../src/session'
 
 //
@@ -11,7 +11,7 @@ import { session, persist } from '../src/session'
 //
 
 declare let global: any
-let events: ReturnType<typeof createEventsMock>
+let events: Events
 
 test.before(() => {
   global.sessionStorage = createStorageMock()

--- a/tests/storage-sync.test.ts
+++ b/tests/storage-sync.test.ts
@@ -4,7 +4,7 @@ import * as assert from 'uvu/assert'
 import { snoop } from 'snoop'
 import { createStore, createEvent } from 'effector'
 import { createStorageMock } from './mocks/storage.mock'
-import { createEventsMock } from './mocks/events.mock'
+import { type Events, createEventsMock } from './mocks/events.mock'
 import { persist } from '../src/core'
 import { storage } from '../src/storage'
 
@@ -16,7 +16,7 @@ declare let global: any
 
 const mockStorage = createStorageMock()
 let storageAdapter: StorageAdapter
-let events: ReturnType<typeof createEventsMock>
+let events: Events
 
 test.before(() => {
   events = createEventsMock()

--- a/tests/storage-timeout.test.ts
+++ b/tests/storage-timeout.test.ts
@@ -6,7 +6,7 @@ import { snoop } from 'snoop'
 // import { createStore, createEvent } from 'effector'
 import { createStore } from 'effector'
 import { createStorageMock } from './mocks/storage.mock'
-import { createEventsMock } from './mocks/events.mock'
+import { type Events, createEventsMock } from './mocks/events.mock'
 import { persist } from '../src/core'
 import { storage } from '../src/storage'
 
@@ -17,7 +17,7 @@ import { storage } from '../src/storage'
 declare let global: any
 
 const mockStorage = createStorageMock()
-let events: ReturnType<typeof createEventsMock>
+let events: Events
 
 test.before(() => {
   global.clock = installFakeTimers()

--- a/tests/tools-async.test.ts
+++ b/tests/tools-async.test.ts
@@ -4,7 +4,7 @@ import * as assert from 'uvu/assert'
 import { snoop } from 'snoop'
 import { createEvent, createStore } from 'effector'
 import { createStorageMock } from './mocks/storage.mock'
-import { createEventsMock } from './mocks/events.mock'
+import { type Events, createEventsMock } from './mocks/events.mock'
 import { persist, local, async } from '../src'
 
 //
@@ -12,7 +12,7 @@ import { persist, local, async } from '../src'
 //
 
 declare let global: any
-let events: ReturnType<typeof createEventsMock>
+let events: Events
 
 test.before(() => {
   global.localStorage = createStorageMock()

--- a/tests/tools-farcached.test.ts
+++ b/tests/tools-farcached.test.ts
@@ -15,7 +15,7 @@ import {
   inMemoryCache,
 } from '@farfetched/core'
 import { createStorageMock } from './mocks/storage.mock'
-import { createEventsMock } from './mocks/events.mock'
+import { type Events, createEventsMock } from './mocks/events.mock'
 import { persist, farcached } from '../src'
 
 //
@@ -25,7 +25,7 @@ import { persist, farcached } from '../src'
 const NOW = 1_000_000_000_000 // 2001-09-09T01:46:40.000Z
 
 declare let global: any
-let events: ReturnType<typeof createEventsMock>
+let events: Events
 
 test.before(() => {
   global.clock = installFakeTimers({ now: NOW })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,13 @@
 {
   "compilerOptions": {
     "strict": true,
-    "target": "es2018",
+    "target": "es2020",
     "module": "commonjs",
     "moduleResolution": "node",
-    "lib": ["es2018", "dom"],
+    "lib": [
+      "es2020",
+      "dom"
+    ],
     "types": [],
     "skipLibCheck": true,
     "noImplicitAny": true,
@@ -12,6 +15,12 @@
     "noUnusedParameters": true,
     "noEmit": true
   },
-  "include": ["src", "tests"],
-  "exclude": ["**/node_modules", "**/.*/"]
+  "include": [
+    "src",
+    "tests"
+  ],
+  "exclude": [
+    "**/node_modules",
+    "**/.*/"
+  ]
 }


### PR DESCRIPTION
Add disposable adapters — way for adapter to remove event listeners and take some dispose actions if needed.

Fixes #59 